### PR TITLE
python version agnostic in 'getting started'

### DIFF
--- a/doc_generation/static_docs/getting-started.md
+++ b/doc_generation/static_docs/getting-started.md
@@ -12,7 +12,7 @@ git clone https://github.com/spluta/MMMAudio.git
 
 ## 2. Setup the Environment
 
-`cd` into the root of the downloaded repository, set up your virtual environment, and install required libraries. this should work with python 3.12 and 3.13
+`cd` into the root of the downloaded repository, set up your virtual environment, and install required libraries. This should work with python 3.12 and 3.13. If you find it does or doesn't work with other versions [let us know](https://github.com/spluta/MMMAudio/issues).
 
 ```shell
 python -m venv venv


### PR DESCRIPTION
you can ignore the failing check.