### PR TITLE
Remove BufferedInput

### DIFF
--- a/examples/AnalysisExample.mojo
+++ b/examples/AnalysisExample.mojo
@@ -35,7 +35,7 @@ struct AnalysisExample(Movable, Copyable):
     var buffer: Buffer
     var playBuf: Play
     var freq: Float64
-    var analyzer: BufferedInput[CustomAnalysis[1024],WindowType.rect]
+    var analyzer: BufferedProcess[CustomAnalysis[1024],output=False,input_window_shape=WindowType.rect]
     var m: Messenger
     var which: Float64
 
@@ -44,7 +44,7 @@ struct AnalysisExample(Movable, Copyable):
         self.osc = Osc[2](self.world)
         self.buffer = Buffer.load("resources/Shiverer.wav")
         self.playBuf = Play(self.world)
-        self.analyzer = BufferedInput[CustomAnalysis[1024],WindowType.rect](self.world, CustomAnalysis[1024](self.world), window_size=1024, hop_size=512)
+        self.analyzer = BufferedProcess[CustomAnalysis[1024],output=False,input_window_shape=WindowType.rect](self.world, CustomAnalysis[1024](self.world), window_size=1024, hop_size=512)
         self.freq = 440.0
         self.m = Messenger(self.world)
         self.which = 0.0
@@ -60,7 +60,7 @@ struct AnalysisExample(Movable, Copyable):
         sig = select(self.which,[oscs[0], oscs[1], flute])
         
         # do the analysis
-        self.analyzer.next(sig)
+        _ = self.analyzer.next(sig)
 
         # get the results
         (frequency, confidence) = (self.analyzer.process.pitch, self.analyzer.process.pitch_conf)

--- a/examples/FFTBinDelays.mojo
+++ b/examples/FFTBinDelays.mojo
@@ -46,7 +46,7 @@ struct BinDelaysWindow[window_size: Int](FFTProcessable):
 struct FFTBinDelays(Movable, Copyable):
     var world: World
     var buffer: Buffer
-    var fft_bin_delays: FFTProcess[BinDelaysWindow[window_size],WindowType.sine,WindowType.sine]
+    var fft_bin_delays: FFTProcess[BinDelaysWindow[window_size],True,WindowType.sine,WindowType.sine]
     var m: Messenger
     var dur_mult: Float64
     var play: Play
@@ -57,6 +57,7 @@ struct FFTBinDelays(Movable, Copyable):
 
         self.fft_bin_delays = FFTProcess[
                 BinDelaysWindow[window_size],
+                True,
                 WindowType.sine,
                 WindowType.sine
             ](self.world,process=BinDelaysWindow[window_size](self.world), window_size=window_size, hop_size=hop_size)

--- a/examples/MFCCExample.mojo
+++ b/examples/MFCCExample.mojo
@@ -8,7 +8,7 @@ struct MFCCExample(Movable, Copyable):
     var world: World
     var buffer: Buffer
     var playBuf: Play
-    var fftproc: FFTProcess[MFCC,WindowType.hann]
+    var fftproc: FFTProcess[MFCC,False,WindowType.hann]
     var m: Messenger
     var print_counter: Int
     var update_modulus: Int
@@ -18,7 +18,7 @@ struct MFCCExample(Movable, Copyable):
         self.buffer = Buffer.load("resources/Shiverer.wav")
         self.playBuf = Play(self.world)
         p = MFCC(sr=self.world[].sample_rate, num_bands=num_bands, num_coeffs=num_coeffs, min_freq=20.0, max_freq=20000.0, fft_size=fft_size)
-        self.fftproc = FFTProcess[MFCC,WindowType.hann](self.world,p^, window_size=fft_size, hop_size=fft_size//2)
+        self.fftproc = FFTProcess[MFCC,False,WindowType.hann](self.world,p^, window_size=fft_size, hop_size=fft_size//2)
         self.m = Messenger(self.world)
         self.print_counter = 0
         self.update_modulus = 50

--- a/examples/MPlotExample.py
+++ b/examples/MPlotExample.py
@@ -32,7 +32,7 @@ def main():
     # slice using spectral flux
     slice_points = MBufAnalysis.spectral_flux_onsets(d)
 
-    print(len(slice_points))
+    print("num slice points:", len(slice_points))
 
     slice_points = np.insert(slice_points, 0, 0) # add start of file as first slice point
     slice_points = np.append(slice_points, len(y)) # add end of file as last slice point
@@ -52,7 +52,7 @@ def main():
 
     print("data shape:", data.shape)
 
-    data_umap = UMAP(n_components=2,learning_rate=0.1,min_dist=0.1,n_epochs=200).fit_transform(data)
+    data_umap = UMAP(n_components=2,learning_rate=0.1,min_dist=0.01,n_epochs=200).fit_transform(data)
 
     kdtree = KDTree(data_umap)
 

--- a/examples/MelBandsExample.mojo
+++ b/examples/MelBandsExample.mojo
@@ -6,7 +6,7 @@ struct MelBandsExample(Movable, Copyable):
     var world: World
     var buffer: Buffer
     var playBuf: Play
-    var analyzer: FFTProcess[MelBands,WindowType.hann]
+    var analyzer: FFTProcess[MelBands,ifft=False,input_window_shape=WindowType.hann]
     var m: Messenger
     var viz_mul: Float64
     var mix: Float64
@@ -22,7 +22,7 @@ struct MelBandsExample(Movable, Copyable):
         self.buffer = Buffer.load("resources/Shiverer.wav")
         self.playBuf = Play(self.world)
         p = MelBands(self.world[].sample_rate, num_bands, 20.0, 20000.0)
-        self.analyzer = FFTProcess[MelBands,WindowType.hann](self.world,p^, window_size=1024, hop_size=512)
+        self.analyzer = FFTProcess[MelBands,ifft=False,input_window_shape=WindowType.hann](self.world,p^, window_size=1024, hop_size=512)
         self.m = Messenger(self.world)
         self.viz_mul = 500.0
         self.mix = 1.0

--- a/examples/PaulStretch.mojo
+++ b/examples/PaulStretch.mojo
@@ -25,7 +25,7 @@ struct PaulStretch(Movable, Copyable):
     var world: World
     var buffer: Buffer
     var saw: LFSaw[1]
-    var paul_stretch: FFTProcess[PaulStretchWindow[window_size],WindowType.sine,WindowType.sine]
+    var paul_stretch: FFTProcess[PaulStretchWindow[window_size],ifft=True,input_window_shape=WindowType.sine,output_window_shape=WindowType.sine]
     var m: Messenger
     var dur_mult: Float64
 
@@ -36,8 +36,9 @@ struct PaulStretch(Movable, Copyable):
 
         self.paul_stretch = FFTProcess[
                 PaulStretchWindow[window_size],
-                WindowType.sine,
-                WindowType.sine
+                ifft=True,
+                input_window_shape=WindowType.sine,
+                output_window_shape=WindowType.sine
             ](self.world,process=PaulStretchWindow[window_size](self.world),window_size=window_size,hop_size=hop_size)
 
         self.m = Messenger(self.world)

--- a/examples/SpectralFluxOnsetExample.mojo
+++ b/examples/SpectralFluxOnsetExample.mojo
@@ -6,7 +6,7 @@ struct SpectralFluxOnsetExample(Movable, Copyable):
     var world: World
     var buffer: Buffer
     var playBuf: Play
-    var onsets: SpectralFluxOnsets[1]
+    var onsets: SpectralFluxOnsets
     var m: Messenger
     var impulse_vol: Float64
     var onsetcounter: Int64
@@ -15,7 +15,7 @@ struct SpectralFluxOnsetExample(Movable, Copyable):
         self.world = world
         self.buffer = Buffer.load("resources/Shiverer.wav")
         self.playBuf = Play(self.world)
-        self.onsets = SpectralFluxOnsets[1](self.world,(fft_size//2) + 1)
+        self.onsets = SpectralFluxOnsets(self.world,(fft_size//2) + 1)
         self.onsets.thresh = 67.0
         self.onsets.min_slice_len = 0.3
         self.m = Messenger(self.world)

--- a/examples/SpectralFreezeExample.mojo
+++ b/examples/SpectralFreezeExample.mojo
@@ -37,7 +37,7 @@ struct SpectralFreeze[window_size: Int](Movable, Copyable):
 
     comptime hop_size = Self.window_size // 4
     var world: World
-    var freeze: FFTProcess[SpectralFreezeWindow[Self.window_size],WindowType.hann,WindowType.hann]
+    var freeze: FFTProcess[SpectralFreezeWindow[Self.window_size],ifft=True,input_window_shape=WindowType.hann,output_window_shape=WindowType.hann]
     var m: Messenger
     var freeze_gate: Bool
     var asr: ASREnv
@@ -46,8 +46,9 @@ struct SpectralFreeze[window_size: Int](Movable, Copyable):
         self.world = world
         self.freeze = FFTProcess[
                 SpectralFreezeWindow[Self.window_size],
-                WindowType.hann,
-                WindowType.hann
+                ifft=True,
+                input_window_shape=WindowType.hann,
+                output_window_shape=WindowType.hann
             ](self.world,process=SpectralFreezeWindow[Self.window_size](self.world, namespace),window_size=Self.window_size,hop_size=Self.hop_size)
         self.m = Messenger(self.world, namespace)
         self.freeze_gate = False

--- a/examples/tests/TestBufferedProcessAudio.mojo
+++ b/examples/tests/TestBufferedProcessAudio.mojo
@@ -34,7 +34,7 @@ struct TestBufferedProcessAudio(Movable, Copyable):
     var world: World
     var buffer: Buffer
     var playBuf: Play
-    var my_buffered_mul: BufferedProcess[BufferedMultiply,WindowType.rect,WindowType.hann]
+    var my_buffered_mul: BufferedProcess[BufferedMultiply,True,WindowType.rect,WindowType.hann]
     var m: Messenger
     var ps: List[Print]
     var which: Float64
@@ -44,7 +44,7 @@ struct TestBufferedProcessAudio(Movable, Copyable):
         self.buffer = Buffer.load("resources/Shiverer.wav")
         self.playBuf = Play(self.world) 
         var multiply_process = BufferedMultiply(self.world)
-        self.my_buffered_mul = BufferedProcess[BufferedMultiply,WindowType.rect,WindowType.hann](self.world,process=multiply_process^,window_size=1024,hop_size=512)
+        self.my_buffered_mul = BufferedProcess[BufferedMultiply,True,WindowType.rect,WindowType.hann](self.world,process=multiply_process^,window_size=1024,hop_size=512)
         self.m = Messenger(self.world)
         self.ps = List[Print](length=2,fill=Print(self.world))
         self.which = 0

--- a/examples/tests/TestBufferedProcessFFT.mojo
+++ b/examples/tests/TestBufferedProcessFFT.mojo
@@ -39,7 +39,7 @@ struct TestBufferedProcessFFT(Movable, Copyable):
     var world: World
     var buffer: Buffer
     var playBuf: Play
-    var fftlowpass: BufferedProcess[FFTLowPass[window_size],WindowType.sine,WindowType.sine]
+    var fftlowpass: BufferedProcess[FFTLowPass[window_size],True,WindowType.sine,WindowType.sine]
     var m: Messenger
     var ps: List[Print]
     var which: Float64
@@ -48,7 +48,7 @@ struct TestBufferedProcessFFT(Movable, Copyable):
         self.world = world
         self.buffer = Buffer.load("resources/Shiverer.wav")
         self.playBuf = Play(self.world) 
-        self.fftlowpass = BufferedProcess[FFTLowPass[window_size],WindowType.sine,WindowType.sine](self.world,process=FFTLowPass[window_size](self.world),window_size=window_size,hop_size=hop_size)
+        self.fftlowpass = BufferedProcess[FFTLowPass[window_size],True,WindowType.sine,WindowType.sine](self.world,process=FFTLowPass[window_size](self.world),window_size=window_size,hop_size=hop_size)
         self.m = Messenger(self.world)
         self.ps = List[Print](length=2,fill=Print(self.world))
         self.which = 0

--- a/examples/tests/TestFFTProcess.mojo
+++ b/examples/tests/TestFFTProcess.mojo
@@ -71,8 +71,8 @@ struct TestFFTProcess(Movable, Copyable):
     var world: World
     var buffer: Buffer
     var playBuf: Play
-    var onsets: SpectralFluxOnsets[1]
-    var fftlowpass: FFTProcess[ScrambleAndLowPass[windowsize],WindowType.hann,WindowType.hann]
+    var onsets: SpectralFluxOnsets
+    var fftlowpass: FFTProcess[ScrambleAndLowPass[windowsize],True,WindowType.hann,WindowType.hann]
     var m: Messenger
     var ps: List[Print]
     var which: Float64
@@ -81,10 +81,10 @@ struct TestFFTProcess(Movable, Copyable):
         self.world = world
         self.buffer = Buffer.load("resources/Shiverer.wav")
         self.playBuf = Play(self.world) 
-        self.onsets = SpectralFluxOnsets[1](self.world,(windowsize//2) + 1)
+        self.onsets = SpectralFluxOnsets(self.world,(windowsize//2) + 1)
         self.onsets.thresh = 67
         self.onsets.min_slice_len = 0.3
-        self.fftlowpass = FFTProcess[ScrambleAndLowPass[windowsize],WindowType.hann,WindowType.hann](self.world,process=ScrambleAndLowPass[windowsize](self.world),window_size=windowsize,hop_size=hopsize)
+        self.fftlowpass = FFTProcess[ScrambleAndLowPass[windowsize],True,WindowType.hann,WindowType.hann](self.world,process=ScrambleAndLowPass[windowsize](self.world),window_size=windowsize,hop_size=hopsize)
         self.m = Messenger(self.world)
         self.ps = List[Print](length=2,fill=Print(self.world))
         self.which = 0

--- a/examples/tests/TestRMS.mojo
+++ b/examples/tests/TestRMS.mojo
@@ -6,7 +6,7 @@ struct TestRMS(Movable, Copyable):
     var world: World
     var buffer: Buffer
     var playBuf: Play
-    var bi: BufferedInput[RMS]
+    var bi: BufferedProcess[RMS,False,WindowType.rect]
     var m: Messenger
     var printer: Print
     var vol: Float64
@@ -17,7 +17,7 @@ struct TestRMS(Movable, Copyable):
         self.playBuf = Play(self.world) 
         rms = RMS()
         # samplerate of 48000 50 ms for the RMS = 2400 samples
-        self.bi = BufferedInput[RMS](self.world,process=rms^,window_size=2400,hop_size=2400)
+        self.bi = BufferedProcess[RMS,False,WindowType.rect](self.world,process=rms^,window_size=2400,hop_size=2400)
         self.m = Messenger(self.world)
         self.printer = Print(self.world)
         self.vol = 0.0
@@ -29,7 +29,7 @@ struct TestRMS(Movable, Copyable):
         
         i *= dbamp(self.vol)
         
-        self.bi.next(i)
+        _ = self.bi.next(i)
         analysis_vol = ampdb(self.bi.process.rms)
         self.printer.next(analysis_vol, "RMS dB")
         return SIMD[DType.float64,2](i,i)

--- a/mmm_audio/Analysis.mojo
+++ b/mmm_audio/Analysis.mojo
@@ -1263,12 +1263,12 @@ struct SpectralFlux(FFTProcessable, GetFloat64Featurable):
         if self.positive_only:
             for i in range(self.num_mags):
                 var diff = mags[i] - self.prev_mags[i]
-                self.flux += max(0.0, diff) * self.num_mags_reciprocal
+                self.flux += max(0.0, diff) #* self.num_mags_reciprocal
                 self.prev_mags[i] = mags[i]
         else:
             for i in range(self.num_mags):
                 var diff = mags[i] - self.prev_mags[i]
-                self.flux += diff * diff * self.num_mags_reciprocal
+                self.flux += diff * diff #* self.num_mags_reciprocal
                 self.prev_mags[i] = mags[i]
             
         return self.flux
@@ -1342,9 +1342,9 @@ struct SpectralFluxOnsets(Movable,Copyable,GetBoolFeaturable):
 
         onsets = List[Int]()
 
-        for i in range(buf.num_frames):
-            if sf_onsets.next(buf.data[chan][i]):
-                onsets.append(i)
+        for i in range(num_frames):
+            if sf_onsets.next(buf.data[chan][start_frame + i]):
+                onsets.append(start_frame + i)
         
         return onsets^
 

--- a/mmm_audio/Analysis.mojo
+++ b/mmm_audio/Analysis.mojo
@@ -1153,12 +1153,12 @@ struct MFCC(FFTProcessable, GetFloat64Featurable):
 
         self.dct.process(self.db_bands, self.coeffs)
 
-    @staticmethod
-    fn buf_analysis(buf: Buffer, chan: Int = 0, start_frame: Int = 0, var num_frames: Int = -1, num_coeffs: Int = 13, num_bands: Int = 40, min_freq: Float64 = 20.0, max_freq: Float64 = 20000.0, fft_size: Int = 1024, hop_size: Int = 512) raises -> List[List[Float64]]:
-        if num_frames < 0:
-            num_frames = buf.num_frames - start_frame
-        mfcc = MFCC(buf.sample_rate, num_coeffs, num_bands, min_freq, max_freq, fft_size)
-        return MBufAnalysis.fft_process[WindowType.hann](mfcc, buf, chan, start_frame, num_frames, fft_size, hop_size)
+    # @staticmethod
+    # fn buf_analysis(buf: Buffer, chan: Int = 0, start_frame: Int = 0, var num_frames: Int = -1, num_coeffs: Int = 13, num_bands: Int = 40, min_freq: Float64 = 20.0, max_freq: Float64 = 20000.0, fft_size: Int = 1024, hop_size: Int = 512) raises -> List[List[Float64]]:
+    #     if num_frames < 0:
+    #         num_frames = buf.num_frames - start_frame
+    #     mfcc = MFCC(buf.sample_rate, num_coeffs, num_bands, min_freq, max_freq, fft_size)
+    #     return MBufAnalysis.fft_process[T=MFCC,input_win=WindowType.hann](mfcc, buf, chan, start_frame, num_frames, fft_size, hop_size)
 
 struct DCT(Movable,Copyable):
     """Compute the Discrete Cosine Transform (DCT)."""

--- a/mmm_audio/Analysis.mojo
+++ b/mmm_audio/Analysis.mojo
@@ -1153,6 +1153,13 @@ struct MFCC(FFTProcessable, GetFloat64Featurable):
 
         self.dct.process(self.db_bands, self.coeffs)
 
+    @staticmethod
+    fn buf_analysis(buf: Buffer, chan: Int = 0, start_frame: Int = 0, var num_frames: Int = -1, num_coeffs: Int = 13, num_bands: Int = 40, min_freq: Float64 = 20.0, max_freq: Float64 = 20000.0, fft_size: Int = 1024, hop_size: Int = 512) raises -> List[List[Float64]]:
+        if num_frames < 0:
+            num_frames = buf.num_frames - start_frame
+        mfcc = MFCC(buf.sample_rate, num_coeffs, num_bands, min_freq, max_freq, fft_size)
+        return MBufAnalysis.fft_process[WindowType.hann](mfcc, buf, chan, start_frame, num_frames, fft_size, hop_size)
+
 struct DCT(Movable,Copyable):
     """Compute the Discrete Cosine Transform (DCT)."""
 
@@ -1269,7 +1276,7 @@ struct SpectralFlux(FFTProcessable, GetFloat64Featurable):
 trait GetBoolFeaturable:
     fn get_features(self) -> List[Bool]:...
 
-struct SpectralFluxOnsets[num_chans: Int = 1](Movable,Copyable,GetBoolFeaturable):
+struct SpectralFluxOnsets(Movable,Copyable,GetBoolFeaturable):
     """Spectral Flux Onset analysis.
     """
     var world: World
@@ -1280,12 +1287,12 @@ struct SpectralFluxOnsets[num_chans: Int = 1](Movable,Copyable,GetBoolFeaturable
     var filter_size: Int
     var filter: MedianFilter
     var prev_flux: Float64
-    var fftp: FFTProcess[SpectralFlux,WindowType.hann,WindowType.hann]
+    var fftp: FFTProcess[SpectralFlux,ifft=False,input_window_shape=WindowType.hann,output_window_shape=WindowType.hann]
 
     fn get_features(self) -> List[Bool]:
         return [self.state]
 
-    fn __init__(out self, world: World, num_mags: Int, window_size: Int = 1024, hop_size: Int = 512, filter_size: Int = 5):
+    fn __init__(out self, world: World, window_size: Int = 1024, hop_size: Int = 512, filter_size: Int = 5):
         self.world = world
         self.thresh = 0.5
         self.state = False
@@ -1294,8 +1301,8 @@ struct SpectralFluxOnsets[num_chans: Int = 1](Movable,Copyable,GetBoolFeaturable
         self.filter_size = filter_size
         self.filter = MedianFilter(filter_size)
         self.prev_flux = 0.0
-        sfp = SpectralFlux(num_mags=num_mags, positive_only=True)
-        self.fftp = FFTProcess[SpectralFlux,WindowType.hann,WindowType.hann](self.world,process=sfp^, window_size=window_size, hop_size=hop_size)
+        sfp = SpectralFlux(num_mags=(window_size // 2) + 1, positive_only=True)
+        self.fftp = FFTProcess[SpectralFlux,ifft=False,input_window_shape=WindowType.hann,output_window_shape=WindowType.hann](self.world,process=sfp^, window_size=window_size, hop_size=hop_size)
 
     fn next(mut self, input: SIMD[DType.float64,1]) -> Bool:
 
@@ -1322,5 +1329,23 @@ struct SpectralFluxOnsets[num_chans: Int = 1](Movable,Copyable,GetBoolFeaturable
                 self.current_slice_length_samps = 0
 
         return self.state
+    
+    @staticmethod
+    fn buf_analysis(world: World, buf: Buffer, chan: Int = 0, start_frame: Int = 0, var num_frames: Int = -1, thresh: Float64 = 0.5, min_slice_len: Float64 = 1.0, window_size: Int = 1024, hop_size: Int = 512, filter_size: Int = 5) raises -> List[Int]:
+        if num_frames < 0:
+            num_frames = buf.num_frames - start_frame
+
+        # run the analysis
+        sf_onsets = SpectralFluxOnsets(world,window_size,hop_size,filter_size)
+        sf_onsets.thresh = thresh
+        sf_onsets.min_slice_len = min_slice_len
+
+        onsets = List[Int]()
+
+        for i in range(buf.num_frames):
+            if sf_onsets.next(buf.data[chan][i]):
+                onsets.append(i)
+        
+        return onsets^
 
 

--- a/mmm_audio/BufferedProcess_Module.mojo
+++ b/mmm_audio/BufferedProcess_Module.mojo
@@ -27,79 +27,12 @@ trait BufferedProcessable(Movable, Copyable):
     fn get_messages(mut self) -> None:
         return None
 
-struct BufferedInput[T: BufferedProcessable, input_window_shape: Int = WindowType.hann](Movable, Copyable):
+struct BufferedProcess[T: BufferedProcessable, output: Bool = True, input_window_shape: Int = WindowType.hann, output_window_shape: Int = WindowType.hann](Movable, Copyable):
     """Buffers input samples and hands them over to be processed in 'windows'.
 
     Parameters:
         T: A user defined struct that implements the [BufferedProcessable](BufferedProcess.md/#trait-bufferedprocessable) trait.
-        input_window_shape: Window shape to apply to the input samples before passing them to the user defined struct. Use comptime variables from [WindowType](MMMWorld.md/#struct-windowtype) struct (e.g. WindowType.hann).
-    """
-    var world: World
-    var window_size: Int
-    var hop_size: Int
-    var input_buffer: List[Float64]
-    var passing_buffer: List[Float64]
-    var input_buffer_write_head: Int
-    var hop_counter: Int
-    var process: Self.T
-    var input_attenuation_window: List[Float64]
-
-    fn __init__(out self, world: World, var process: Self.T, window_size: Int, hop_size: Int, hop_start: Int = 0):
-        """Initializes a BufferedInput struct.
-
-        Args:
-            world: A pointer to the MMMWorld.
-            process: A user defined struct that implements the [BufferedProcessable](BufferedProcess.md/#trait-bufferedprocessable) trait.
-            window_size: The size of the window to process. This will determine how many samples are passed to the user defined struct's `.next_window()` method on each call.
-            hop_size: The number of samples between each processed window.
-            hop_start: The initial value of the hop counter. Default is 0. This can be used to offset the processing start time, if for example, you need to offset the start time of the first frame. This can be useful when separating windows into separate `BufferedInput`s, and therefore separate audio streams, so that each window could be routed or processed with different FX chains.
-
-        Returns:
-            An initialized `BufferedInput` struct.
-        """
-        
-        self.world = world
-        self.window_size = window_size
-        self.hop_size = hop_size
-        self.input_buffer_write_head = 0
-        self.hop_counter = hop_start
-        self.process = process^
-        self.input_buffer = List[Float64](length=self.window_size * 2, fill=0.0)
-        self.passing_buffer = List[Float64](length=self.window_size, fill=0.0)
-
-        self.input_attenuation_window = Windows.make_window[Self.input_window_shape](self.window_size)
-
-    fn next(mut self, input: Float64) -> None:
-        """Process the next input sample and return the next output sample.
-        
-        This function is called in the audio processing loop for each input sample. It buffers the input samples,
-        and internally here calls the user defined struct's `.next_window()` method every `hop_size` samples.
-
-        Args:
-            input: The next input sample to process.
-        """
-        if self.world[].top_of_block:
-            self.process.get_messages()
-    
-        self.input_buffer[self.input_buffer_write_head] = input
-        self.input_buffer[self.input_buffer_write_head + self.window_size] = input
-        self.input_buffer_write_head = (self.input_buffer_write_head + 1) % self.window_size
-        
-        if self.hop_counter == 0:
-
-            for i in range(self.window_size):
-                self.passing_buffer[i] = self.input_buffer[self.input_buffer_write_head + i] * self.input_attenuation_window[i]
-
-            self.process.next_window(self.passing_buffer)
-    
-        self.hop_counter = (self.hop_counter + 1) % self.hop_size
-
-
-struct BufferedProcess[T: BufferedProcessable, input_window_shape: Int = WindowType.hann, output_window_shape: Int = WindowType.hann](Movable, Copyable):
-    """Buffers input samples and hands them over to be processed in 'windows'.
-
-    Parameters:
-        T: A user defined struct that implements the [BufferedProcessable](BufferedProcess.md/#trait-bufferedprocessable) trait.
+        output: A boolean specifying whether this BufferedProcess will be outputting audio. It can be useful to set this to `false` if you only want to analyze the input audio in windows without outputting any audio.
         input_window_shape: Window shape to apply to the input samples before passing them to the user defined struct. Use comptime variables from [WindowType](MMMWorld.md/#struct-windowtype) struct (e.g. WindowType.hann).
         output_window_shape: Window shape to apply to the output samples after processing by the user defined struct. Use comptime variables from [WindowType](MMMWorld.md/#struct-windowtype) struct (e.g. WindowType.hann).
     """
@@ -181,6 +114,10 @@ struct BufferedProcess[T: BufferedProcessable, input_window_shape: Int = WindowT
 
             self.process.next_window(self.passing_buffer)
 
+            @parameter
+            if not Self.output:
+                return 0.0
+
             for i in range(self.window_size):
                 self.output_buffer[(self.output_buffer_write_head + i) % self.window_size] += self.passing_buffer[i] * self.output_attenuation_window[i]
 
@@ -220,6 +157,10 @@ struct BufferedProcess[T: BufferedProcessable, input_window_shape: Int = WindowT
 
             self.process.next_stereo_window(self.st_passing_buffer)
 
+            @parameter
+            if not Self.output:
+                return 0.0
+
             for i in range(self.window_size):
                 self.st_output_buffer[(self.output_buffer_write_head + i) % self.window_size] += self.st_passing_buffer[i] * self.output_attenuation_window[i]
 
@@ -252,6 +193,10 @@ struct BufferedProcess[T: BufferedProcessable, input_window_shape: Int = WindowT
                 self.passing_buffer[i] = SpanInterpolator.read_none[bWrap=False](buffer.data[chan], index) * self.input_attenuation_window[i]
 
             self.process.next_window(self.passing_buffer)
+
+            @parameter
+            if not Self.output:
+                return 0.0
 
             for i in range(self.window_size):
                 self.output_buffer[(self.output_buffer_write_head + i) % self.window_size] += self.passing_buffer[i] * self.output_attenuation_window[i]
@@ -286,6 +231,9 @@ struct BufferedProcess[T: BufferedProcessable, input_window_shape: Int = WindowT
                 self.st_passing_buffer[i][1] = SpanInterpolator.read_none[bWrap=False](buffer.data[start_chan + 1], index) * self.input_attenuation_window[i]
 
             self.process.next_stereo_window(self.st_passing_buffer)
+            @parameter
+            if not Self.output:
+                return 0.0
 
             for i in range(self.window_size):
                 self.st_output_buffer[(self.output_buffer_write_head + i) % self.window_size] += self.st_passing_buffer[i] * self.output_attenuation_window[i]

--- a/mmm_audio/ComplexFFTProcess_Module.mojo
+++ b/mmm_audio/ComplexFFTProcess_Module.mojo
@@ -65,9 +65,10 @@ struct ComplexFFTProcess[T: ComplexFFTProcessable, window_size: Int = 1024, hop_
         hop_size: The number of samples between each processed spectral frame.
         input_window_shape: Int specifying what window shape to use to modify the amplitude of the input samples before the FFT. See [WindowType](MMMWorld.md/#struct-windowtype) for the options.
         output_window_shape: Int specifying what window shape to use to modify the amplitude of the output samples after the IFFT. See [WindowType](MMMWorld.md/#struct-windowtype) for the options.
+        ifft: Bool specifying whether to perform the inverse FFT after processing. Defaults to True.
     """
     var world: World
-    var buffered_process: BufferedProcess[ComplexFFTProcessor[Self.T, Self.window_size], Self.input_window_shape, Self.output_window_shape]
+    var buffered_process: BufferedProcess[ComplexFFTProcessor[Self.T, Self.window_size], True, Self.input_window_shape, Self.output_window_shape]
 
     fn __init__(out self, world: World, var process: Self.T):
         """Initializes a `FFTProcess` struct.
@@ -80,7 +81,7 @@ struct ComplexFFTProcess[T: ComplexFFTProcessable, window_size: Int = 1024, hop_
             An initialized `FFTProcess` struct.
         """
         self.world = world
-        self.buffered_process = BufferedProcess[ComplexFFTProcessor[Self.T, Self.window_size], Self.input_window_shape, Self.output_window_shape](self.world, process=ComplexFFTProcessor[Self.T, Self.window_size](self.world, process=process^), window_size=Self.window_size, hop_size=Self.hop_size)
+        self.buffered_process = BufferedProcess[ComplexFFTProcessor[Self.T, Self.window_size], True, Self.input_window_shape, Self.output_window_shape](self.world, process=ComplexFFTProcessor[Self.T, Self.window_size](self.world, process=process^), window_size=Self.window_size, hop_size=Self.hop_size)
 
     fn next(mut self, input: Float64) -> Float64:
         """Processes the next input sample and returns the next output sample.

--- a/mmm_audio/FFTProcess_Module.mojo
+++ b/mmm_audio/FFTProcess_Module.mojo
@@ -1,7 +1,7 @@
 from mmm_audio import *
 
 @doc_private
-struct FFTProcessor[T: FFTProcessable](BufferedProcessable):
+struct FFTProcessor[T: FFTProcessable, ifft: Bool = True](BufferedProcessable):
     """This is a private struct that the user doesn't *need* to see or use. This is the
     connective tissue between FFTProcess (which the user *does* see and uses to
     create spectral processes) and BufferedProcess. To learn how this whole family of structs 
@@ -33,12 +33,15 @@ struct FFTProcessor[T: FFTProcessable](BufferedProcessable):
     fn next_window(mut self, mut input: List[Float64]) -> None:
         self.fft.fft(input)
         self.process.next_frame(self.fft.mags,self.fft.phases)
-        self.fft.ifft(input)
+        if Self.ifft:
+            self.fft.ifft(input)
     
     fn next_stereo_window(mut self, mut input: List[SIMD[DType.float64,2]]) -> None:
         self.fft2.fft(input)
         self.process.next_stereo_frame(self.fft2.mags,self.fft2.phases)
-        self.fft2.ifft(input)
+        @parameter
+        if Self.ifft:
+            self.fft2.ifft(input)
 
     @doc_private
     fn get_messages(mut self) -> None:
@@ -58,18 +61,19 @@ trait FFTProcessable(Movable,Copyable):
     fn get_messages(mut self) -> None:
         return None
 
-struct FFTProcess[T: FFTProcessable, input_window_shape: Int = WindowType.hann, output_window_shape: Int = WindowType.hann](Movable,Copyable):
+struct FFTProcess[T: FFTProcessable, ifft: Bool = True,input_window_shape: Int = WindowType.hann, output_window_shape: Int = WindowType.hann](Movable,Copyable):
     """Create an FFTProcess for audio manipulation in the frequency domain.
 
     Parameters:
         T: A user defined struct that implements the [FFTProcessable](FFTProcess.md/#trait-fftprocessable) trait.
+        ifft: A boolean specifying whether to perform an IFFT after processing in the frequency domain. Set to `false` if you only want to analyze the magnitudes and phases without converting back to the time domain.
         input_window_shape: Int specifying what window shape to use to modify the amplitude of the input samples before the FFT. See [WindowType](MMMWorld.md/#struct-windowtype) for the options.
         output_window_shape: Int specifying what window shape to use to modify the amplitude of the output samples after the IFFT. See [WindowType](MMMWorld.md/#struct-windowtype) for the options.
     """
     var world: World
     var window_size: Int
     var hop_size: Int
-    var buffered_process: BufferedProcess[FFTProcessor[Self.T], Self.input_window_shape, Self.output_window_shape]
+    var buffered_process: BufferedProcess[FFTProcessor[Self.T, Self.ifft], output=Self.ifft, input_window_shape=Self.input_window_shape, output_window_shape=Self.output_window_shape]
 
     fn __init__(out self, world: World, var process: Self.T, window_size: Int, hop_size: Int):
         """Initializes a `FFTProcess` struct.
@@ -86,8 +90,8 @@ struct FFTProcess[T: FFTProcessable, input_window_shape: Int = WindowType.hann, 
         self.world = world
         self.window_size = window_size
         self.hop_size = hop_size
-        p = FFTProcessor[Self.T](self.world, process=process^, window_size=self.window_size)
-        self.buffered_process = BufferedProcess[FFTProcessor[Self.T],Self.input_window_shape, Self.output_window_shape](self.world, process=p^,window_size=self.window_size, hop_size=self.hop_size)
+        p = FFTProcessor[Self.T, Self.ifft](self.world, process=process^, window_size=self.window_size)
+        self.buffered_process = BufferedProcess[FFTProcessor[Self.T, Self.ifft], output=Self.ifft, input_window_shape=Self.input_window_shape, output_window_shape=Self.output_window_shape](self.world, process=p^,window_size=self.window_size, hop_size=self.hop_size)
 
     fn next(mut self, input: Float64) -> Float64:
         """Processes the next input sample and returns the next output sample.

--- a/mmm_audio/MBufAnalysisBridge.mojo
+++ b/mmm_audio/MBufAnalysisBridge.mojo
@@ -168,7 +168,7 @@ struct MBufAnalysisBridge:
     fn spectral_flux_onsets(py_dict: PythonObject) raises -> PythonObject:
         # make the analysis params instance
         analysis_params = AnalysisParams(py_dict)
-        thresh = getFloat64(py_dict, "thresh", 68.0)
+        thresh = getFloat64(py_dict, "thresh", 0.01)
         window_size = getInt(py_dict, "window_size", 1024)
         hop_size = getInt(py_dict, "hop_size", window_size // 2)
         filter_size = getInt(py_dict, "filter_size", 5)

--- a/mmm_audio/MBufAnalysisBridge.mojo
+++ b/mmm_audio/MBufAnalysisBridge.mojo
@@ -6,7 +6,7 @@ from os import abort
 from mmm_audio import *
 
 @export
-fn PyInit_MBufAnalysis() -> PythonObject:
+fn PyInit_MBufAnalysisBridge() -> PythonObject:
     try:
         var m = PythonModuleBuilder("MBufAnalysisBridge")
         m.def_function[MBufAnalysisBridge.rms]("rms")
@@ -213,7 +213,7 @@ struct MBufAnalysisBridge:
 
 struct MBufAnalysis:
 
-    # [TODO]: add windowing
+    # # [TODO]: add windowing
     @staticmethod
     fn buffered_process[T: GetFloat64Featurable & BufferedProcessable](mut analyzer: T,analysis_params: AnalysisParams, window_size: Int = 1024, hop_size: Int = 512) raises -> List[List[Float64]]:
         return MBufAnalysis.buffered_process(analyzer, analysis_params.buf, analysis_params.chan, analysis_params.start_frame, analysis_params.num_frames, window_size, hop_size)

--- a/mmm_audio/MBufAnalysis_Module.mojo
+++ b/mmm_audio/MBufAnalysis_Module.mojo
@@ -6,7 +6,7 @@ from os import abort
 from mmm_audio import *
 
 @export
-fn PyInit_MBufAnalysisBridge() -> PythonObject:
+fn PyInit_MBufAnalysis() -> PythonObject:
     try:
         var m = PythonModuleBuilder("MBufAnalysisBridge")
         m.def_function[MBufAnalysisBridge.rms]("rms")
@@ -88,7 +88,7 @@ struct MBufAnalysisBridge:
         max_freq = getFloat64(py_dict, "max_freq", 20000.0)
         
         mel_bands = MelBands(ap.buf.sample_rate, num_bands, min_freq, max_freq, window_size)
-        result = MBufAnalysisBridge.fft_process[WindowType.hann](mel_bands, ap, window_size=window_size, hop_size=hop_size)
+        result = MBufAnalysis.fft_process[WindowType.hann](mel_bands, ap, window_size=window_size, hop_size=hop_size)
 
         return MBufAnalysisBridge.matrix_to_numpy(result)
 
@@ -105,7 +105,7 @@ struct MBufAnalysisBridge:
         mfcc = MFCC(ap.buf.sample_rate, num_coeffs, num_bands, min_freq, max_freq)
         window_size = getInt(py_dict, "window_size", 1024)
         hop_size = getInt(py_dict, "hop_size", window_size // 2)
-        result = MBufAnalysisBridge.fft_process[WindowType.hann](mfcc, ap, window_size=window_size, hop_size=hop_size)
+        result = MBufAnalysis.fft_process[WindowType.hann](mfcc, ap, window_size=window_size, hop_size=hop_size)
         
         # return it as a numpy array
         return MBufAnalysisBridge.matrix_to_numpy(result)
@@ -120,7 +120,7 @@ struct MBufAnalysisBridge:
         rms = RMS()
         window_size = getInt(py_dict, "window_size", 1024)
         hop_size = getInt(py_dict, "hop_size", window_size // 2)
-        result = MBufAnalysisBridge.buffered_process(rms, analysis_params, window_size=window_size, hop_size=hop_size)
+        result = MBufAnalysis.buffered_process(rms, analysis_params, window_size=window_size, hop_size=hop_size)
         
         # return it as a numpy array
         return MBufAnalysisBridge.matrix_to_numpy(result)
@@ -144,7 +144,7 @@ struct MBufAnalysisBridge:
         yin = YIN(ap.buf.sample_rate, window_size, min_freq=min_freq, max_freq=max_freq)
 
         # run the analysis
-        result = MBufAnalysisBridge.buffered_process(yin,ap, window_size=window_size, hop_size=hop_size)
+        result = MBufAnalysis.buffered_process(yin,ap, window_size=window_size, hop_size=hop_size)
         
         # return it as a numpy array
         return MBufAnalysisBridge.matrix_to_numpy(result)
@@ -159,7 +159,7 @@ struct MBufAnalysisBridge:
 
         # # run the analysis
         sc = SpectralCentroid(analysis_params.buf.sample_rate, min_freq=min_freq, max_freq=max_freq, power_mag=power_mag)
-        result = MBufAnalysisBridge.fft_process[WindowType.hann](sc, analysis_params)
+        result = MBufAnalysis.fft_process[WindowType.hann](sc, analysis_params)
         
         # return it as a numpy array
         return MBufAnalysisBridge.matrix_to_numpy(result)
@@ -178,11 +178,11 @@ struct MBufAnalysisBridge:
         w.init_pointee_move(MMMWorld(analysis_params.buf.sample_rate))
 
         # run the analysis
-        sf_onsets = SpectralFluxOnsets[1](w,(window_size // 2) + 1,window_size,hop_size,filter_size)
+        sf_onsets = SpectralFluxOnsets(w,window_size,hop_size,filter_size)
         sf_onsets.thresh = thresh
         sf_onsets.min_slice_len = min_slice_len
 
-        onsets = List[Int64]()
+        onsets = List[Int]()
 
         for i in range(analysis_params.buf.num_frames):
             samp = analysis_params.buf.data[analysis_params.chan][i]
@@ -191,52 +191,15 @@ struct MBufAnalysisBridge:
 
         # return it as a numpy array
         return MBufAnalysisBridge.list_to_numpy(onsets)
-
+    
     @staticmethod
-    fn list_to_numpy(list: List[Int64]) raises -> PythonObject:
+    fn list_to_numpy(list: List[Int]) raises -> PythonObject:
         np = Python.import_module("numpy")
         shape = Python.tuple(Int(len(list)))
         nparray = np.zeros(shape=shape,dtype=np.int64)
         for i in range(len(list)):
             nparray[i] = list[i]
         return nparray
-
-    # [TODO]: add windowing
-    @staticmethod
-    fn buffered_process[T: GetFloat64Featurable & BufferedProcessable](mut analyzer: T,analysis_params: AnalysisParams, window_size: Int = 1024, hop_size: Int = 512) raises -> List[List[Float64]]:
-        result = List[List[Float64]]()
-        frame: Int64 = analysis_params.start_frame
-        window_samps = List[Float64](length=window_size,fill=0.0)
-        while frame < analysis_params.start_frame + analysis_params.num_frames:
-            for i in range(window_size):
-                if frame + i < analysis_params.buf.num_frames:
-                    window_samps[i] = analysis_params.buf.data[analysis_params.chan][frame + i]
-                else:
-                    window_samps[i] = 0.0
-            analyzer.next_window(window_samps)
-            result.append(analyzer.get_features())
-            frame += hop_size
-        return result^
-
-    @staticmethod
-    fn fft_process[T: GetFloat64Featurable & FFTProcessable,//,input_win: Int = WindowType.hann](mut analyzer: T, analysis_params: AnalysisParams, window_size: Int = 1024, hop_size: Int = 512) raises -> List[List[Float64]]:
-        result = List[List[Float64]]()
-        frame: Int64 = analysis_params.start_frame
-        window_samps = List[Float64](length=window_size,fill=0.0)
-        fft = RealFFT(window_size)
-        window_func = Windows.make_window[input_win](window_size)
-        while frame < analysis_params.start_frame + analysis_params.num_frames:
-            for i in range(window_size):
-                if frame + i < analysis_params.buf.num_frames:
-                    window_samps[i] = analysis_params.buf.data[analysis_params.chan][frame + i] * window_func[i]
-                else:
-                    window_samps[i] = 0.0
-            # apply window function
-            fft.fft(window_samps)
-            analyzer.next_frame(fft.mags,fft.phases)
-            result.append(analyzer.get_features())
-            frame += hop_size
-        return result^
 
     @staticmethod
     fn matrix_to_numpy(list: List[List[Float64]]) raises -> PythonObject:
@@ -247,6 +210,58 @@ struct MBufAnalysisBridge:
             for j in range(len(list[i])):
                 nparray[i][j] = list[i][j]
         return nparray
+
+struct MBufAnalysis:
+
+    # [TODO]: add windowing
+    @staticmethod
+    fn buffered_process[T: GetFloat64Featurable & BufferedProcessable](mut analyzer: T,analysis_params: AnalysisParams, window_size: Int = 1024, hop_size: Int = 512) raises -> List[List[Float64]]:
+        return MBufAnalysis.buffered_process(analyzer, analysis_params.buf, analysis_params.chan, analysis_params.start_frame, analysis_params.num_frames, window_size, hop_size)
+
+    # [TODO]: add windowing
+    @staticmethod
+    fn buffered_process[T: GetFloat64Featurable & BufferedProcessable](mut analyzer: T,buf: Buffer, chan: Int, start_frame: Int, var num_frames: Int, window_size: Int = 1024, hop_size: Int = 512) raises -> List[List[Float64]]:
+        result = List[List[Float64]]()
+        frame: Int64 = start_frame
+        if num_frames < 0:
+            num_frames = buf.num_frames - start_frame
+        window_samps = List[Float64](length=window_size,fill=0.0)
+        while frame < start_frame + num_frames:
+            for i in range(window_size):
+                if frame + i < buf.num_frames:
+                    window_samps[i] = buf.data[chan][frame + i]
+                else:
+                    window_samps[i] = 0.0
+            analyzer.next_window(window_samps)
+            result.append(analyzer.get_features())
+            frame += hop_size
+        return result^
+
+    @staticmethod
+    fn fft_process[T: GetFloat64Featurable & FFTProcessable,//,input_win: Int = WindowType.hann](mut analyzer: T, analysis_params: AnalysisParams, window_size: Int = 1024, hop_size: Int = 512) raises -> List[List[Float64]]:
+        return MBufAnalysis.fft_process[input_win](analyzer, analysis_params.buf, analysis_params.chan, analysis_params.start_frame, analysis_params.num_frames, window_size, hop_size)
+    
+    @staticmethod
+    fn fft_process[T: GetFloat64Featurable & FFTProcessable,//,input_win: Int = WindowType.hann](mut analyzer: T, buf: Buffer, chan: Int, start_frame: Int, var num_frames: Int, window_size: Int = 1024, hop_size: Int = 512) raises -> List[List[Float64]]:
+        result = List[List[Float64]]()
+        frame: Int64 = start_frame
+        if num_frames < 0:
+            num_frames = buf.num_frames - start_frame
+        window_samps = List[Float64](length=window_size,fill=0.0)
+        fft = RealFFT(window_size)
+        window_func = Windows.make_window[input_win](window_size)
+        while frame < start_frame + num_frames:
+            for i in range(window_size):
+                if frame + i < buf.num_frames:
+                    window_samps[i] = buf.data[chan][frame + i] * window_func[i]
+                else:
+                    window_samps[i] = 0.0
+            # apply window function
+            fft.fft(window_samps)
+            analyzer.next_frame(fft.mags,fft.phases)
+            result.append(analyzer.get_features())
+            frame += hop_size
+        return result^
 
     # @staticmethod
     # fn custom(py_path: PythonObject) raises -> PythonObject:

--- a/mmm_audio/__init__.mojo
+++ b/mmm_audio/__init__.mojo
@@ -9,6 +9,7 @@ from .Envelopes import *
 from .FFTProcess_Module import *
 from .FFTs import *
 from .Filters import *
+from .MBufAnalysis_Module import *
 from .MLP_Module import *
 from .MedianFilter_Module import *
 from .Noise import *

--- a/mmm_audio/__init__.mojo
+++ b/mmm_audio/__init__.mojo
@@ -9,7 +9,7 @@ from .Envelopes import *
 from .FFTProcess_Module import *
 from .FFTs import *
 from .Filters import *
-from .MBufAnalysis_Module import *
+from .MBufAnalysisBridge import *
 from .MLP_Module import *
 from .MedianFilter_Module import *
 from .Noise import *


### PR DESCRIPTION
Because it's duplicate code. Now BufferedProcess can be told wether it should prepare and deliver output samples or not. 

Similarly, FFTProcess now has a flag as to wether or not it should do the IFFT, so that when it is being used for analysis it doesn't waste computation on that.