### PR TITLE
Fix SIMDBuffer to read correct channel(s)

### DIFF
--- a/mmm_audio/sound_file.mojo
+++ b/mmm_audio/sound_file.mojo
@@ -395,6 +395,7 @@ def read_wav_SIMDs[num_channels: Int](file_name: String, header: WavHeader, num_
                 
                 SIMD_sample[ch] = sample_value
                 offset += bytes_per_sample
+            offset += (filenum_channels - read_chans) * bytes_per_sample
             samples.append(SIMD_sample)
     else:
         # definitely need to check this


### PR DESCRIPTION
I was trying load a `SIMDBuffer` as 1 channel (I wanted just the left channel). The `.wav` file I was trying load was stereo. What I got was a single channel of SIMD floats that was 2x the number of samples in the source file, so I think it was loading L, R, L, R as a mono file.

This seems to fix it.