### PR TITLE
Interp Enum

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@
 * The interpolation `fn`s are not owned by anything. They will live in `.functions`. They get called as `fn`s in `Player`
 * trait `Playable`
   * `def __getitem__`
-  * `def at_phase[interp: Int = Interp.none]` for convenience re: windowing, etc.
+  * `def at_phase[interp: Interp = Interp.none]` for convenience re: windowing, etc.
 * struct `Buffer` is for loading sound files and VWTs.
   * `var sample_rate`
 * struct `OscBuffer` will hold wavetables 2^14 in size

--- a/examples/BenjolinExample.mojo
+++ b/examples/BenjolinExample.mojo
@@ -13,11 +13,11 @@ struct Benjolin(Movable, Copyable):
     var m: Messenger
     var feedback: Float64
     var rungler: Float64
-    var tri1: Osc[interp=2,os_index=1]
-    var tri2: Osc[interp=2,os_index=1]
-    var pulse1: Osc[interp=2,os_index=1]
-    var pulse2: Osc[interp=2,os_index=1]
-    var delays: List[Delay[1,3]]
+    var tri1: Osc[interp=Interp.quad,os_index=1]
+    var tri2: Osc[interp=Interp.quad,os_index=1]
+    var pulse1: Osc[interp=Interp.quad,os_index=1]
+    var pulse2: Osc[interp=Interp.quad,os_index=1]
+    var delays: List[Delay[1,Interp.cubic]]
     var latches: List[Latch[]]
     var filters: List[SVF[]]
     var filter_outputs: List[Float64]
@@ -44,11 +44,11 @@ struct Benjolin(Movable, Copyable):
         self.m = Messenger(self.world)
         self.feedback = 0.0
         self.rungler = 0.0
-        self.tri1 = Osc[interp=2,os_index=1](self.world)
-        self.tri2 = Osc[interp=2,os_index=1](self.world)
-        self.pulse1 = Osc[interp=2,os_index=1](self.world)
-        self.pulse2 = Osc[interp=2,os_index=1](self.world)
-        self.delays = List[Delay[1,3]](capacity=8)
+        self.tri1 = Osc[interp=Interp.quad,os_index=1](self.world)
+        self.tri2 = Osc[interp=Interp.quad,os_index=1](self.world)
+        self.pulse1 = Osc[interp=Interp.quad,os_index=1](self.world)
+        self.pulse2 = Osc[interp=Interp.quad,os_index=1](self.world)
+        self.delays = List[Delay[1,Interp.cubic]](capacity=8)
         self.latches = List[Latch[]](capacity=8)
         self.filters = List[SVF[]](capacity=9)
         self.filter_outputs = List[Float64](capacity=9)
@@ -71,7 +71,7 @@ struct Benjolin(Movable, Copyable):
         self.outSignalR = 3
 
         for _ in range(8):
-            self.delays.append(Delay[1,3](self.world, max_delay_time=0.1))
+            self.delays.append(Delay[1,Interp.cubic](self.world, max_delay_time=0.1))
             self.latches.append(Latch())
 
         for _ in range(9):

--- a/examples/ChowningFM.mojo
+++ b/examples/ChowningFM.mojo
@@ -3,8 +3,8 @@ from mmm_audio import *
 struct ChowningFM(Movable, Copyable):
     var world: World # pointer to the MMMWorld
     var m: Messenger
-    var c_osc: Osc[1,1,1]  # Carrier oscillator
-    var m_osc: Osc[1]  # Modulator oscillator
+    var c_osc: Osc[1,Interp.linear,1]  # Carrier oscillator
+    var m_osc: Osc[1,Interp.linear,1]  # Modulator oscillator
     var index_env: Env
     var amp_env: Env
     var cfreq: Float64
@@ -14,8 +14,8 @@ struct ChowningFM(Movable, Copyable):
     def __init__(out self, world: World):
         self.world = world
         self.m = Messenger(self.world)
-        self.c_osc = Osc[1,1,1](self.world)
-        self.m_osc = Osc[1](self.world)
+        self.c_osc = Osc[1,Interp.linear,1](self.world)
+        self.m_osc = Osc[1,Interp.linear,1](self.world)
         self.index_env = Env(self.world)
         self.amp_env = Env(self.world)
         self.cfreq = 200.0

--- a/examples/FeedbackDelaysGUI.mojo
+++ b/examples/FeedbackDelaysGUI.mojo
@@ -6,7 +6,7 @@ struct DelaySynth(Movable, Copyable):
     var main_lag: Lag[1]
     var buf: Buffer
     var playBuf: Play
-    var delays: FB_Delay[num_chans=2, interp=4]  # FB_Delay with 2 channels and interpolation type 3 ()
+    var delays: FB_Delay[num_chans=2, interp=Interp.lagrange4]  # FB_Delay with 2 channels and interpolation type 3 ()
     var delay_time_lag: Lag[2]
     var m: Messenger
     var gate_lag: Lag[1]
@@ -25,7 +25,7 @@ struct DelaySynth(Movable, Copyable):
         self.main_lag = Lag[1](self.world, 0.03)
         self.buf = Buffer.load("resources/Shiverer.wav")
         self.playBuf = Play(self.world) 
-        self.delays = FB_Delay[num_chans=2, interp=4](self.world, self.maxdelay) 
+        self.delays = FB_Delay[num_chans=2, interp=Interp.lagrange4](self.world, self.maxdelay) 
         self.delay_time_lag = Lag[2](self.world, 0.2)  # Initialize Lag with a default time constant
         self.m = Messenger(self.world)
         self.gate_lag = Lag[1](self.world, 0.03)

--- a/examples/tests/TestOscOversampling.mojo
+++ b/examples/tests/TestOscOversampling.mojo
@@ -6,10 +6,10 @@ from mmm_audio import *
 struct TestOscOversampling(Movable, Copyable):
     var world: World
     var osc: Osc[]
-    var osc1: Osc[1,1,1]
-    var osc2: Osc[1,1,2]
-    var osc3: Osc[1,1,3]
-    var osc4: Osc[1,1,4]
+    var osc1: Osc[1,Interp.linear,1]
+    var osc2: Osc[1,Interp.linear,2]
+    var osc3: Osc[1,Interp.linear,3]
+    var osc4: Osc[1,Interp.linear,4]
     var which: Float64
     var messenger: Messenger
     var lag: Lag[]
@@ -17,10 +17,10 @@ struct TestOscOversampling(Movable, Copyable):
     def __init__(out self, world: World):
         self.world = world
         self.osc = Osc(world)
-        self.osc1 = Osc[1,1,1](world)
-        self.osc2 = Osc[1,1,2](world)
-        self.osc3 = Osc[1,1,3](world)
-        self.osc4 = Osc[1,1,4](world)
+        self.osc1 = Osc[1,Interp.linear,1](world)
+        self.osc2 = Osc[1,Interp.linear,2](world)
+        self.osc3 = Osc[1,Interp.linear,3](world)
+        self.osc4 = Osc[1,Interp.linear,4](world)
         self.which = 0.0
         self.messenger = Messenger(world)
         self.lag = Lag(world, 0.1)

--- a/mmm_audio/Buffer_Module.mojo
+++ b/mmm_audio/Buffer_Module.mojo
@@ -246,7 +246,7 @@ struct SpanInterpolator(Movable, Copyable):
     # a reference to the MMMWorld is not needed for every read call.
     @always_inline
     @staticmethod
-    def read[num_chans: Int = 1, interp: Int = Interp.none, bWrap: Bool = True, mask: Int = 0](world: World, data: Span[MFloat[num_chans], ...], f_idx: Float64, prev_f_idx: Float64 = 0.0) -> MFloat[num_chans]:
+    def read[num_chans: Int = 1, interp: Interp = Interp.none, bWrap: Bool = True, mask: Int = 0](world: World, data: Span[MFloat[num_chans], ...], f_idx: Float64, prev_f_idx: Float64 = 0.0) -> MFloat[num_chans]:
         """Read a value from a Span[MFloat[num_chans], ...] using provided index and interpolation method, which is determined at compile time.
         
         Parameters:

--- a/mmm_audio/BufferedProcess_Module.mojo
+++ b/mmm_audio/BufferedProcess_Module.mojo
@@ -181,7 +181,7 @@ struct BufferedProcess[T: BufferedProcessable, output: Bool = True, input_window
         self.read_head = (self.read_head + 1) % self.window_size
         return outval
 
-    def next_from_buffer[interp: Int = Interp.none, bWrap: Bool = False](mut self, ref buffer: SIMDBuffer[1], phase: Float64, chan: Int = 0) -> Float64:
+    def next_from_buffer[interp: Interp = Interp.none, bWrap: Bool = False](mut self, ref buffer: SIMDBuffer[1], phase: Float64, chan: Int = 0) -> Float64:
         """Used for non-real-time, buffer-based, processing. At the onset of the next window, reads a block of window_size samples from the provided buffer, starting at the given phase and channel. Phase values between zero and one will read samples within the provided buffer. If the provided phase tries to read samples with an index below zero or above the duration of the buffer, zeros will be returned.
 
         Args:
@@ -226,7 +226,7 @@ struct BufferedProcess[T: BufferedProcessable, output: Bool = True, input_window
         self.read_head = (self.read_head + 1) % self.window_size
         return outval
 
-    def next_from_stereo_buffer[interp: Int = Interp.none, bWrap: Bool = False](mut self, ref buffer: SIMDBuffer[2], phase: Float64) -> SIMD[DType.float64,2]:
+    def next_from_stereo_buffer[interp: Interp = Interp.none, bWrap: Bool = False](mut self, ref buffer: SIMDBuffer[2], phase: Float64) -> SIMD[DType.float64,2]:
         """Used for non-real-time, buffer-based, processing of stereo files. At the onset of the next window, reads a window_size block of samples from the provided buffer, starting at the given phase and channel. Phase values between zero and one will read samples within the provided buffer. If the provided phase results in reading samples with an index below zero or above the duration of the buffer, zeros will be returned.
 
         Args:

--- a/mmm_audio/Delays.mojo
+++ b/mmm_audio/Delays.mojo
@@ -11,7 +11,7 @@ trait Tapable(Movable, Copyable):
 #     def tap[num_chans: Int](mut self, delay_time: MFloat[num_chans]) -> MFloat[num_chans]:
 #       ...
 
-struct Delay[num_chans: Int = 1, interp: Int = Interp.linear](Tapable):
+struct Delay[num_chans: Int = 1, interp: Interp = Interp.linear](Tapable):
     """A variable delay line with interpolation.
 
     Parameters:
@@ -227,7 +227,7 @@ def calc_feedback[num_chans: Int = 1](delaytime: MFloat[num_chans], decaytime: M
 
       return zero.select(MFloat[num_chans](0.0), dec_pos.select(absret, -absret))
 
-struct Comb[num_chans: Int = 1, interp: Int = 2](Tapable):
+struct Comb[num_chans: Int = 1, interp: Interp = Interp.quad](Tapable):
     """
     A simple comb filter using a delay line with feedback.
 
@@ -288,7 +288,7 @@ struct Comb[num_chans: Int = 1, interp: Int = 2](Tapable):
         feedback = calc_feedback(delay_time, decay_time)
         return self.next(input, delay_time, feedback)
 
-struct LP_Comb[num_chans: Int = 1, interp: Int = Interp.linear](Tapable):
+struct LP_Comb[num_chans: Int = 1, interp: Interp = Interp.linear](Tapable):
     """
     A simple comb filter with an integrated one-pole low-pass filter.
     
@@ -340,7 +340,7 @@ struct LP_Comb[num_chans: Int = 1, interp: Int = Interp.linear](Tapable):
 
         return out
 
-struct Allpass[num_chans: Int = 1, interp: Int = Interp.linear](Tapable):
+struct Allpass[num_chans: Int = 1, interp: Interp = Interp.linear](Tapable):
     """
     A simple allpass filter using a delay line with feedback.
     
@@ -412,7 +412,7 @@ struct Allpass[num_chans: Int = 1, interp: Int = Interp.linear](Tapable):
         return self.next(input, delay_time, feedback)
         
 
-struct FB_Delay[num_chans: Int = 1, interp: Int = Interp.lagrange4, ADAA_dist: Bool = False, os_index: Int = 0](Tapable):
+struct FB_Delay[num_chans: Int = 1, interp: Interp = Interp.lagrange4, ADAA_dist: Bool = False, os_index: Int = 0](Tapable):
     """A feedback delay structured like a Comb filter, but with possible feedback coefficient above 1 due to an integrated tanh function.
     
     By default, Anti-aliasing is disabled and no [oversampling](Oversampling.md) is applied, but this can be changed by setting the ADAA_dist and os_index template parameters.

--- a/mmm_audio/Envelopes.mojo
+++ b/mmm_audio/Envelopes.mojo
@@ -88,7 +88,7 @@ struct Env(Movable, Copyable):
         else:
             self.freq = 0.0
 
-    def next[win_type: Int = WindowType.none, interp: Int = Interp.none](mut self, trig: Bool = True) -> Float64:
+    def next[win_type: Int = WindowType.none, interp: Interp = Interp.none](mut self, trig: Bool = True) -> Float64:
          """Generate the next envelope value. Uses the internal `params` struct for envelope parameters. See `EnvParams` for more details on the parameters. Uses an internal phasor to track the progression of the envelope, which is reset on each trigger.
 
         Parameters:
@@ -135,7 +135,7 @@ struct Env(Movable, Copyable):
         
         return env
 
-    def next[win_type: Int = WindowType.none, interp: Int = Interp.linear](mut self, trig: Bool, phase: MFloat[1]) -> MFloat[1]:
+    def next[win_type: Int = WindowType.none, interp: Interp = Interp.linear](mut self, trig: Bool, phase: MFloat[1]) -> MFloat[1]:
         """Generate the next envelope value with a provided phase rather than using the internal phasor. Works well with a Line UGen. Uses the internal `params` struct for envelope parameters. See `EnvParams` for more details on the parameters.
 
         Parameters:
@@ -177,7 +177,7 @@ struct Env(Movable, Copyable):
         return clip(self.sweep.phase, 0.0, 1.0)
 
     @staticmethod
-    def get_env_buffer[num_chans: Int = 1, win_type: Int = WindowType.none, interp: Int = Interp.linear](world: World, size: Int, *env_defs: EnvParams) -> SIMDBuffer[num_chans]:
+    def get_env_buffer[num_chans: Int = 1, win_type: Int = WindowType.none, interp: Interp = Interp.linear](world: World, size: Int, *env_defs: EnvParams) -> SIMDBuffer[num_chans]:
         """Get a SIMDBuffer of envelope values.
 
         Args:
@@ -200,7 +200,7 @@ struct Env(Movable, Copyable):
                 buffer.data[j][i] = env.next[win_type, interp](True, phase)
         return buffer^
 
-def win_read[window_type: Int = WindowType.sine, interp: Int = Interp.none](world: World, phase: MFloat[1]) -> MFloat[1]:
+def win_read[window_type: Int = WindowType.sine, interp: Interp = Interp.none](world: World, phase: MFloat[1]) -> MFloat[1]:
     """Reads a window function from MMMWorld's default Window by indexing into it with the provided phase.
 
     Parameters:
@@ -218,7 +218,7 @@ def win_read[window_type: Int = WindowType.sine, interp: Int = Interp.none](worl
     val = temp[].at_phase[window_type, interp](world, phase)
     return val
 
-def buf_read[num_chans: Int, interp: Int = Interp.linear, bWrap: Bool = True](world: World, env_buffer: SIMDBuffer[num_chans], phase: MFloat[1], prev_phase: MFloat[1] = 0.0) -> MFloat[num_chans]:
+def buf_read[num_chans: Int, interp: Interp = Interp.linear, bWrap: Bool = True](world: World, env_buffer: SIMDBuffer[num_chans], phase: MFloat[1], prev_phase: MFloat[1] = 0.0) -> MFloat[num_chans]:
     """Reads a buffer by indexing into it with the provided phase.
 
     Args:
@@ -247,7 +247,7 @@ def buf_read[num_chans: Int, interp: Int = Interp.linear, bWrap: Bool = True](wo
     return val
 
 # min_env is just a function, not a struct
-def min_env[win_type: Int = WindowType.none, interp: Int = Interp.none](world: World, phase: MFloat[1] = 0.0, ramp_amount: MFloat[1] = 0.01) -> MFloat[1]:
+def min_env[win_type: Int = WindowType.none, interp: Interp = Interp.none](world: World, phase: MFloat[1] = 0.0, ramp_amount: MFloat[1] = 0.01) -> MFloat[1]:
     """Simple envelope.
 
     Envelope that creates a simple trapezoidal envelope with linear ramps. The attack and release ramps are determined by the `ramp_amount` parameter.
@@ -301,7 +301,7 @@ struct ASREnv(Movable, Copyable):
         self.eoc_rbd = RisingBoolDetector() 
         self.world = world
 
-    def next[win_type: Int = WindowType.none, interp: Int = Interp.none](mut self, attack: Float64, sustain: Float64, release: Float64, gate: Bool, curve: MFloat[2] = 1) -> Float64:
+    def next[win_type: Int = WindowType.none, interp: Interp = Interp.none](mut self, attack: Float64, sustain: Float64, release: Float64, gate: Bool, curve: MFloat[2] = 1) -> Float64:
         """Simple ASR envelope generator.
         
         Parameters:

--- a/mmm_audio/MMMWorld_Module.mojo
+++ b/mmm_audio/MMMWorld_Module.mojo
@@ -129,29 +129,36 @@ struct MMMWorld(Movable, Copyable):
 # ========================================
 # once Mojo has enums, these will probably be converted to enums
 
-struct Interp:
+@fieldwise_init
+struct Interp(Equatable, ImplicitlyCopyable):
     """Interpolation types for use in various UGens.
 
     Specify an interpolation type by typing it explicitly.
-    For example, to specify linear interpolation, one could use the number `1`, 
-    but it is clearer to type `Interp.linear`.
 
-    | Interpolation Type | Value | Notes                                        |
-    | ------------------ | ----- | -------------------------------------------- |
-    | Interp.none        | 0     |                                              |
-    | Interp.linear      | 1     |                                              |
-    | Interp.quad        | 2     |                                              |
-    | Interp.cubic       | 3     |                                              |
-    | Interp.lagrange4   | 4     |                                              |
-    | Interp.sinc        | 5     | Should only be used with oscillators         |
+    | Interpolation Type | Notes                                       |
+    | ------------------ | ------------------------------------------- |
+    | Interp.none        |                                             |
+    | Interp.linear      |                                             |
+    | Interp.quad        |                                             |
+    | Interp.cubic       |                                             |
+    | Interp.lagrange4   |                                             |
+    | Interp.sinc        | Should only be used with oscillators        |
     
     """
-    comptime none: Int = 0
-    comptime linear: Int = 1
-    comptime quad: Int = 2
-    comptime cubic: Int = 3
-    comptime lagrange4: Int = 4
-    comptime sinc: Int = 5
+    var _value: Int
+
+    comptime none = Interp(0)
+    comptime linear = Interp(1)
+    comptime quad = Interp(2)
+    comptime cubic = Interp(3)
+    comptime lagrange4 = Interp(4)
+    comptime sinc = Interp(5)
+
+    def __eq__(self, other: Self) -> Bool:
+        return self._value == other._value
+
+    def __ne__(self, other: Self) -> Bool:
+        return not (self == other)
 
 struct WindowType:
     """Window types for predefined windows found in world[].windows.

--- a/mmm_audio/Oscillators.mojo
+++ b/mmm_audio/Oscillators.mojo
@@ -154,7 +154,7 @@ struct Impulse[num_chans: Int = 1, os_index: Int = 0](Movable, Copyable):
 
         return self.phasor.next_impulse(freq, phase_offset, trig)
 
-struct Osc[num_chans: Int = 1, interp: Int = Interp.linear, os_index: Int = 0](Movable, Copyable):
+struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, os_index: Int = 0](Movable, Copyable):
     """Wavetable Oscillator Core.
 
     A wavetable oscillator capable of all standard waveforms and also able to load custom wavetables. Capable of linear, cubic, quadratic, lagrange, or sinc interpolation. Also capable of [Oversampling](Oversampling.md).
@@ -676,7 +676,7 @@ struct TTrig(Movable, Copyable):
             self.counter = Int(time * self.world[].sample_rate)
         return self.next(False, 0)
 
-struct LFNoise[num_chans: Int = 1, interp: Int = Interp.cubic](Movable, Copyable):
+struct LFNoise[num_chans: Int = 1, interp: Interp = Interp.cubic](Movable, Copyable):
     """Low-frequency interpolating noise generator generating numbers between -1.0 and 1.0. With stepped (none), linear, or cubic interpolation.
 
     Parameters:
@@ -866,7 +866,7 @@ struct OscBuffers(Movable, Copyable):
     var buffers: List[List[Float64]]
     var basic_waveforms: List[MFloat[4]]
 
-    def at_phase[osc_type: Int, interp: Int = Interp.none](self, world: World, phase: Float64, prev_phase: Float64 = 0) -> Float64:
+    def at_phase[osc_type: Int, interp: Interp = Interp.none](self, world: World, phase: Float64, prev_phase: Float64 = 0) -> Float64:
         comptime if osc_type < 4 and osc_type >= 0:
             return SpanInterpolator.read[
                 interp=interp,
@@ -881,7 +881,7 @@ struct OscBuffers(Movable, Copyable):
         else:
             return 0.0
 
-    def at_phase_basic_waveform[osc_type: Int, interp: Int = Interp.none](self, world: World, phase: Float64, prev_phase: Float64 = 0) -> MFloat[4]:
+    def at_phase_basic_waveform[osc_type: Int, interp: Interp = Interp.none](self, world: World, phase: Float64, prev_phase: Float64 = 0) -> MFloat[4]:
         return SpanInterpolator.read[
             num_chans = 4,
             interp=interp,

--- a/mmm_audio/Player.mojo
+++ b/mmm_audio/Player.mojo
@@ -30,7 +30,7 @@ struct Play(Movable, Copyable):
         self.reset_phase_point = 0.0
         self.phase_offset = 0.0
 
-    def next[num_chans: Int = 1, interp: Int = Interp.linear, bWrap: Bool = False](mut self, buf: SIMDBuffer[num_chans], rate: Float64 = 1, loop: Bool = True, trig: Bool = True, start_frame: Int = 0, var num_frames: Int = -1) -> MFloat[num_chans]: 
+    def next[num_chans: Int = 1, interp: Interp = Interp.linear, bWrap: Bool = False](mut self, buf: SIMDBuffer[num_chans], rate: Float64 = 1, loop: Bool = True, trig: Bool = True, start_frame: Int = 0, var num_frames: Int = -1) -> MFloat[num_chans]: 
         """Get the next sample from a SIMD audio buf (SIMDBuffer). The internal phasor is advanced according to the specified rate. If a trigger is received, playback starts at the specified start_frame. If looping is enabled, playback will loop back to the start when reaching the end of the specified num_frames. A key difference between SIMDBuffer and Buffer is that calling next on a SIMDBuffer always returns the entire SIMD vector of samples for the current phase, whereas with Buffer, you can specify the number of channels to read.
 
         Parameters:
@@ -89,7 +89,7 @@ struct Play(Movable, Copyable):
 
     @doc_hidden
     @always_inline
-    def get_sample[num_chans: Int, interp: Int, bWrap: Bool = False](self, buf: SIMDBuffer[num_chans], prev_phase: Float64) -> MFloat[num_chans]:
+    def get_sample[num_chans: Int, interp: Interp, bWrap: Bool = False](self, buf: SIMDBuffer[num_chans], prev_phase: Float64) -> MFloat[num_chans]:
         f_idx = ((self.impulse.phase + self.phase_offset)) * buf.num_frames_f64
         out = SpanInterpolator.read[num_chans, interp=interp,bWrap=bWrap](
                 world=self.world,
@@ -100,7 +100,7 @@ struct Play(Movable, Copyable):
         return out
 
     @always_inline
-    def next[num_chans: Int = 1, interp: Int = Interp.linear, bWrap: Bool = False](mut self, buf: Buffer, rate: Float64 = 1, loop: Bool = True, trig: Bool = True, start_frame: Int = 0, var num_frames: Int = -1, start_chan: Int = 0) -> MFloat[num_chans]: 
+    def next[num_chans: Int = 1, interp: Interp = Interp.linear, bWrap: Bool = False](mut self, buf: Buffer, rate: Float64 = 1, loop: Bool = True, trig: Bool = True, start_frame: Int = 0, var num_frames: Int = -1, start_chan: Int = 0) -> MFloat[num_chans]: 
         """Get the next sample from an audio buf (Buffer). The internal phasor is advanced according to the specified rate. If a trigger is received, playback starts at the specified start_frame. If looping is enabled, playback will loop back to the start when reaching the end of the specified num_frames.
 
         Parameters:
@@ -158,7 +158,7 @@ struct Play(Movable, Copyable):
 
     @doc_hidden
     @always_inline
-    def get_sample[num_chans: Int, interp: Int, bWrap: Bool = False](self, buf: Buffer, prev_phase: Float64, start_chan: Int) -> MFloat[num_chans]:
+    def get_sample[num_chans: Int, interp: Interp, bWrap: Bool = False](self, buf: Buffer, prev_phase: Float64, start_chan: Int) -> MFloat[num_chans]:
         
         out = MFloat[num_chans](0.0)
         comptime for out_chan in range(num_chans):

--- a/mmm_audio/ReverbsDelayFX.mojo
+++ b/mmm_audio/ReverbsDelayFX.mojo
@@ -92,7 +92,7 @@ struct Freeverb[num_chans: Int = 1](Movable, Copyable):
 
 comptime dattoro_sr = 29761.
 
-struct DattorroReverb[interp: Int = Interp.none](Movable, Copyable):
+struct DattorroReverb[interp: Interp = Interp.none](Movable, Copyable):
   """Dattorro reverb algorithm created by Jon Dattorro in his classic paper "Effect Design Part 1: Reverberator and Other Filters".
   
   Parameters:
@@ -285,7 +285,7 @@ struct Phaser[num_chans: Int = 1, stages: Int = 8](Movable, Copyable):
         return (allpass_out * wet_dry[0]) + (input * wet_dry[1])
 
 
-struct Flanger[num_chans: Int = 1, interp: Int = Interp.lagrange4](Movable, Copyable):
+struct Flanger[num_chans: Int = 1, interp: Interp = Interp.lagrange4](Movable, Copyable):
     """A flanger effect implemented as a single comb filter with the delay time modulated by an LFO.
 
     Parameters:

--- a/mmm_audio/Windows_Module.mojo
+++ b/mmm_audio/Windows_Module.mojo
@@ -21,7 +21,7 @@ struct Windows(Movable, Copyable):
         self.kaiser = kaiser_window(self.size, 5.0)
         self.pan2 = pan2_window(256)
 
-    def at_phase[window_type: Int,interp: Int = Interp.none](self, world: World, phase: Float64, prev_phase: Float64 = 0.0) -> Float64:
+    def at_phase[window_type: Int,interp: Interp = Interp.none](self, world: World, phase: Float64, prev_phase: Float64 = 0.0) -> Float64:
         """Get window value at given phase (0.0 to 1.0) for specified window type."""
 
         comptime if window_type == WindowType.hann:


### PR DESCRIPTION
This PR implements the `Interp` Enum (or, Modular-endorsed Mojo-style Enum). This makes code more readable, encourages clarity, and avoids user foot-guns.

Any user code that was already using the faux enums (e.g., `Interp.linear`) will still work excellently. Any user code that was using `Int` to specify interpolation will need to now use the enum.

This addresses issue #160 , however before it can be closed the full migration will also include `OscType` and `WindowType` and possibly also an Enum for `osc_index` since that is not really an "`Int`", but in fact a selection of an option.