### PR TITLE
MLP Changes

### DIFF
--- a/examples/TorchMlp.py
+++ b/examples/TorchMlp.py
@@ -7,14 +7,13 @@ synth.
 You can also train the Multi-Layer Perceptron by creating any number of input/output pairs and making a new training. When training the MLP, temporarily disable the MLP inference so you can set the synth parameters directly.
 """
 
-if True:
-    from mmm_python import *
-    from random import random
+from mmm_python import *
+from random import random
 
-    mmm_audio = MMMAudio(128, in_device=None, graph_name="TorchMlp", package_name="examples")
+mmm_audio = MMMAudio(128, in_device=None, graph_name="TorchMlp", package_name="examples")
 
-    # this one is a bit intense, so maybe start with a low volume
-    mmm_audio.start_audio()
+# this one is a bit intense, so maybe start with a low volume
+mmm_audio.start_audio()
 
 # below is the code to make a new training --------------------------------
 
@@ -80,10 +79,10 @@ def do_the_training():
 
     # train the network in a separate thread so the audio thread doesn't get interrupted
 
-    from mmm_audio.MLP_Python import train_nn
+    from mmm_audio.MLP_Python import train_new_mlp
     import threading
 
-    target_function = train_nn
+    target_function = train_new_mlp
     args = (X_train_list, y_train_list, layers, learn_rate, epochs, "examples/nn_trainings/model_traced.pt")
 
     # Create a Thread object

--- a/mmm_audio/MLP_Python.py
+++ b/mmm_audio/MLP_Python.py
@@ -1,4 +1,4 @@
-"""Contains a Multi-Layer Perceptron (MLP) implementation using PyTorch and the train_nn function to train the network."""
+"""Contains a Multi-Layer Perceptron (MLP) implementation using PyTorch and the train_new_mlp function to train the network."""
 
 import torch
 import time
@@ -47,7 +47,13 @@ class MLP(nn.Module):
         """Get the output size of the MLP."""
         return self.output_size
     
-def train_nn(X_train_list: list[list[float]], y_train_list: list[list[float]], layers: list[tuple[int, str | None]], learn_rate: float, epochs: int, file_name: str):
+activations = {
+    'relu': nn.ReLU(),
+    'sigmoid': nn.Sigmoid(),
+    'tanh': nn.Tanh()
+}
+    
+def train_new_mlp(X_train_list: list[list[float]], y_train_list: list[list[float]], layers: list[tuple[int, str | None]], learn_rate: float, epochs: int, file_name: str):
     """Train the MLP and save the trained model.
 
     Args:
@@ -65,23 +71,15 @@ def train_nn(X_train_list: list[list[float]], y_train_list: list[list[float]], l
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print("Using device:", device)
 
-
     print(layers)
 
     for i, vals in enumerate(layers):
         print(f"Layer {i}: {vals}")
         val, activation = vals
         if activation is not None:
-            if activation == 'relu':
-                activation = nn.ReLU()
-            elif activation == 'sigmoid':
-                activation = nn.Sigmoid()
-            elif activation == 'tanh':
-                activation = nn.Tanh()
-            else:
-                raise ValueError("Activation function not recognized.")
-        layers[i] = [val, activation]
+            activation = activations[activation]
 
+        layers[i] = [val, activation]
 
     print(layers)
 


### PR DESCRIPTION
closes #123 

Address both items discussed in the issue:

1. Changing activation function selection from series of `elif`s to `dict` lookup
2. Renames `train_nn` to `train_new_mlp`. I liked putting "mlp" in there since that's the name of the example, the struct, etc.