### PR TITLE
Avoid `List` allocation in `TopNIndices`

### DIFF
--- a/mmm_audio/Analysis.mojo
+++ b/mmm_audio/Analysis.mojo
@@ -1370,6 +1370,7 @@ struct TopNFreqs(FFTProcessable, GetFloat64Featurable):
     var num_peaks: Int
     var sort_by_freq: Bool
     var bin_freq: Float64
+    var top_n_indices: TopNIndices
     
     def get_features(self) -> List[Float64]:
         state = List[Float64]()
@@ -1398,12 +1399,13 @@ struct TopNFreqs(FFTProcessable, GetFloat64Featurable):
         self.num_peaks = num_peaks
         self.sort_by_freq = sort_by_freq
         self.bin_freq = sample_rate / Float64(self.window_size)
+        self.top_n_indices = TopNIndices()
 
     def get_messages(mut self) -> None:
         pass
 
     def next_frame(mut self, mut mags: List[MFloat[]], mut phases: List[MFloat[]]) -> None:
-        top_N = topN_indices(mags, self.num_peaks, self.thresh)
+        ref top_N = self.top_n_indices.process(mags, self.num_peaks,self.thresh)
 
         for i in range(self.num_peaks):
             index = top_N[i]

--- a/mmm_audio/functions.mojo
+++ b/mmm_audio/functions.mojo
@@ -791,41 +791,53 @@ def rotate_left_inplace[T: Movable & Copyable & ImplicitlyCopyable](mut data: Li
     reverse(data, n, len(data) - 1)  # Reverse second part
     reverse(data, 0, len(data) - 1)  # Reverse entire array
 
-def topN_indices(in_list: List[Float64], N: Int=5, thresh: Float64 = 100.0) -> List[Int]:
-    """Return the indices of the top N largest values in the array.
-    
-    Args:
-        in_list: Input list of Float64 values.
-        N: The number of top values to return.
-        thresh: The minimum value to include in the list.
-    
-    Returns:
-        A list of indices corresponding to the top N peaks in in_list that are above the threshold. Will return 0s if there are not enough peaks above the threshold. 0 is not a valid index.
-    """
-    # sort_list = in_list.copy()
-    top_N = [Int(0) for _ in range(N)]
+struct TopNIndices(Movable,Copyable):
+    var output_indices: List[Int]
+    var ordinal: List[Int]
 
-    def argsort(in_list: List[Float64]) -> List[Int]:
-        var indices = List[Int]()
-        for i in range(len(in_list)):
-            indices.append(i)
+    def __init__(out self):
+        self.output_indices = List[Int]()
+        self.ordinal = List[Int]()
+
+    def process(mut self, in_list: List[Float64], N: Int, thresh: Float64 = 100.0) -> ref[origin_of(self.output_indices)] List[Int]:
+        """Return the indices of the top N largest values in the array.
+        
+        Args:
+            in_list: Input list of Float64 values.
+            N: The number of top indices to return.
+            thresh: The minimum value to include in the list.
+        
+        Returns:
+            A list of indices corresponding to the top N peaks in in_list that are above the threshold. Will return 0s if there are not enough peaks above the threshold. 0 is not a valid index.
+        """
+
+        in_list_len: Int = len(in_list)
+
+        self.ordinal.resize(in_list_len, 0)
+
+        for i in range(in_list_len):
+            self.ordinal[i] = i
 
         def cmp_fn(a: Int, b: Int) capturing -> Bool:
             return in_list[a] > in_list[b]
 
-        sort[cmp_fn](indices)
-        return indices^
+        sort[cmp_fn](self.ordinal)
 
-    indices = argsort(in_list)
-    place_idx = 0
-    i = 0
-    while place_idx < N and in_list[indices[place_idx]] >= thresh and i < (3*N):
-        idx = indices[i]
-        if in_list[idx-1]<in_list[idx] and in_list[idx+1]<in_list[idx]:
-            top_N[place_idx] = idx
-            place_idx += 1
-        i += 1
-    return top_N^
+        self.output_indices.clear()
+
+        place_idx = 0
+        i = 0
+        while place_idx < N and in_list[self.ordinal[place_idx]] >= thresh and i < (3*N):
+            idx = self.ordinal[i]
+            # TODO: this index checking probably shouldn't wrap around.
+            previdx = (idx - 1) % in_list_len
+            nextidx = (idx + 1) % in_list_len
+            if in_list[previdx] < in_list[idx] and in_list[nextidx] < in_list[idx]:
+                # self.output_indices[place_idx] = idx
+                self.output_indices.append(idx)
+                place_idx += 1
+            i += 1
+        return self.output_indices
 
 def find_quadratic_peak(p1: Float64, p2: Float64, p3: Float64) -> Tuple[Float64, Float64]:
     """

--- a/testing_mmm_audio/UnitTests.mojo
+++ b/testing_mmm_audio/UnitTests.mojo
@@ -647,5 +647,29 @@ def test_select_files() raises:
     for expected in expected_files2:
         assert_true(expected in files2, "Test: select_files missing expected file " + expected)
 
+def test_top_n_indices() raises:
+    tpi = TopNIndices()
+    n: Int = 3
+
+    arr: List[Float64] = [0.1, 0.5, 0.3, 0.9, 0.2, 0.8, 0.7]
+    ref result = tpi.process(arr, n, 0.01)
+    expected: List[Int] = [3, 5, 1]
+    assert_equal(result, expected, "Test: top_n_indices function failed")
+
+    arr2: List[Float64] = [0.99, 0.5, 0.3, 0.9, 0.2, 0.8, 0.7]
+    ref result2 = tpi.process(arr2, n, 0.01)
+    expected: List[Int] = [0, 3, 5]
+    assert_equal(result2, expected, "Test: top_n_indices function failed")
+
+    arr3: List[Float64] = [0.1, 0.5, 0.3, 0.9, 0.2, 0.8, 0.99]
+    ref result3 = tpi.process(arr3, n, 0.01)
+    expected: List[Int] = [6, 3, 1]
+    assert_equal(result3, expected, "Test: top_n_indices function failed")
+
+    arr4: List[Float64] = [0.6, 0.1, 0.1, 0.2, 0.1, 0.7, 0.1]
+    ref result4 = tpi.process(arr4, n, 0.3)
+    expected: List[Int] = [5, 0]
+    assert_equal(result4, expected, "Test: top_n_indices function failed")
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Befoer this can be merged, there is some lingering undefined behavior to address: *What should be returned if there aren't "N" peaks or there aren't "N" peaks above the threshold?*

## Options:

1. Return fewer than N indices? I don't like that very much because If i ask for "N" things back, I very likely might do something later expecting "N" things in my list!
2. Return `-1`s meaning that there weren't enough peaks to fill N spots in the list? I don't like that because these numbers are expected to be indices and -1 is going to cause an error.
3. Duplicate some of the indices to fill out the `List` to "N" elements?
4. Just start adding other *tall* values to the array?

Also, you'll notice that `self.ordinal` gets resized. This will usually not happen because it's likely the `in_list` will be the same length every time, so it will really only happen on the *first* pass.

Lastly, `self.output_indices` gets cleared and then appended to. That's pretty much `List` allocation in the audio process... choosing an option from above will allow that list to only grow or shrink when the user passes in a new "N", which is probably very rare.