### PR TITLE
`WindowType` Enum

### DIFF
--- a/examples/Grains_Custom.mojo
+++ b/examples/Grains_Custom.mojo
@@ -79,7 +79,7 @@ struct GrainBPF(GrainObject):
 
     @always_inline
     # this is a stereo grain, but you can make a pan_az grain by making a .next_az function instead
-    def next_2[num_buf_chans: Int, num_playback_chans: Int = 1, win_type: Int = WindowType.hann, custom_curve: Int = WindowType.hann, bWrap: Bool = False](mut self, buffer: SIMDBuffer[num_buf_chans]) -> MFloat[2]:
+    def next_2[num_buf_chans: Int, num_playback_chans: Int = 1, win_type: WindowType = WindowType.hann, custom_curve: WindowType = WindowType.hann, bWrap: Bool = False](mut self, buffer: SIMDBuffer[num_buf_chans]) -> MFloat[2]:
         
         # get all the channels from the grain
         var sample = self.grain.next_all[win_type=win_type, custom_curve=custom_curve, bWrap=bWrap](buffer)

--- a/mmm_audio/BufferedProcess_Module.mojo
+++ b/mmm_audio/BufferedProcess_Module.mojo
@@ -27,7 +27,7 @@ trait BufferedProcessable(Movable, Copyable, ImplicitlyDestructible):
     def get_messages(mut self) -> None:
         return None
 
-struct BufferedProcess[T: BufferedProcessable, output: Bool = True, input_window_shape: Int = WindowType.hann, output_window_shape: Int = WindowType.hann](Movable, Copyable):
+struct BufferedProcess[T: BufferedProcessable, output: Bool = True, input_window_shape: WindowType = WindowType.hann, output_window_shape: WindowType = WindowType.hann](Movable, Copyable):
     """Buffers input samples and hands them over to be processed in 'windows'.
 
     Parameters:

--- a/mmm_audio/ComplexFFTProcess_Module.mojo
+++ b/mmm_audio/ComplexFFTProcess_Module.mojo
@@ -60,7 +60,7 @@ trait ComplexFFTProcessable(Movable,Copyable, ImplicitlyDestructible):
     def get_messages(mut self) -> None:
         return None
 
-struct ComplexFFTProcess[T: ComplexFFTProcessable, ifft: Bool = True,input_window_shape: Int = WindowType.hann, output_window_shape: Int = WindowType.hann](Movable,Copyable):
+struct ComplexFFTProcess[T: ComplexFFTProcessable, ifft: Bool = True,input_window_shape: WindowType = WindowType.hann, output_window_shape: WindowType = WindowType.hann](Movable,Copyable):
     """Create an FFTProcess for audio manipulation in the frequency domain. This version will output and input complex frequency bins directly rather than magnitude and phase. This is currently untested.
 
     Parameters:

--- a/mmm_audio/Envelopes.mojo
+++ b/mmm_audio/Envelopes.mojo
@@ -88,7 +88,7 @@ struct Env(Movable, Copyable):
         else:
             self.freq = 0.0
 
-    def next[win_type: Int = WindowType.none, interp: Interp = Interp.none](mut self, trig: Bool = True) -> Float64:
+    def next[win_type: WindowType = WindowType.none, interp: Interp = Interp.none](mut self, trig: Bool = True) -> Float64:
          """Generate the next envelope value. Uses the internal `params` struct for envelope parameters. See `EnvParams` for more details on the parameters. Uses an internal phasor to track the progression of the envelope, which is reset on each trigger.
 
         Parameters:
@@ -135,7 +135,7 @@ struct Env(Movable, Copyable):
         
         return env
 
-    def next[win_type: Int = WindowType.none, interp: Interp = Interp.linear](mut self, trig: Bool, phase: MFloat[1]) -> MFloat[1]:
+    def next[win_type: WindowType = WindowType.none, interp: Interp = Interp.linear](mut self, trig: Bool, phase: MFloat[1]) -> MFloat[1]:
         """Generate the next envelope value with a provided phase rather than using the internal phasor. Works well with a Line UGen. Uses the internal `params` struct for envelope parameters. See `EnvParams` for more details on the parameters.
 
         Parameters:
@@ -177,7 +177,7 @@ struct Env(Movable, Copyable):
         return clip(self.sweep.phase, 0.0, 1.0)
 
     @staticmethod
-    def get_env_buffer[num_chans: Int = 1, win_type: Int = WindowType.none, interp: Interp = Interp.linear](world: World, size: Int, *env_defs: EnvParams) -> SIMDBuffer[num_chans]:
+    def get_env_buffer[num_chans: Int = 1, win_type: WindowType = WindowType.none, interp: Interp = Interp.linear](world: World, size: Int, *env_defs: EnvParams) -> SIMDBuffer[num_chans]:
         """Get a SIMDBuffer of envelope values.
 
         Args:
@@ -200,7 +200,7 @@ struct Env(Movable, Copyable):
                 buffer.data[j][i] = env.next[win_type, interp](True, phase)
         return buffer^
 
-def win_read[window_type: Int = WindowType.sine, interp: Interp = Interp.none](world: World, phase: MFloat[1]) -> MFloat[1]:
+def win_read[window_type: WindowType = WindowType.sine, interp: Interp = Interp.none](world: World, phase: MFloat[1]) -> MFloat[1]:
     """Reads a window function from MMMWorld's default Window by indexing into it with the provided phase.
 
     Parameters:
@@ -247,7 +247,7 @@ def buf_read[num_chans: Int, interp: Interp = Interp.linear, bWrap: Bool = True]
     return val
 
 # min_env is just a function, not a struct
-def min_env[win_type: Int = WindowType.none, interp: Interp = Interp.none](world: World, phase: MFloat[1] = 0.0, ramp_amount: MFloat[1] = 0.01) -> MFloat[1]:
+def min_env[win_type: WindowType = WindowType.none, interp: Interp = Interp.none](world: World, phase: MFloat[1] = 0.0, ramp_amount: MFloat[1] = 0.01) -> MFloat[1]:
     """Simple envelope.
 
     Envelope that creates a simple trapezoidal envelope with linear ramps. The attack and release ramps are determined by the `ramp_amount` parameter.
@@ -301,7 +301,7 @@ struct ASREnv(Movable, Copyable):
         self.eoc_rbd = RisingBoolDetector() 
         self.world = world
 
-    def next[win_type: Int = WindowType.none, interp: Interp = Interp.none](mut self, attack: Float64, sustain: Float64, release: Float64, gate: Bool, curve: MFloat[2] = 1) -> Float64:
+    def next[win_type: WindowType = WindowType.none, interp: Interp = Interp.none](mut self, attack: Float64, sustain: Float64, release: Float64, gate: Bool, curve: MFloat[2] = 1) -> Float64:
         """Simple ASR envelope generator.
         
         Parameters:

--- a/mmm_audio/FFTProcess_Module.mojo
+++ b/mmm_audio/FFTProcess_Module.mojo
@@ -52,7 +52,7 @@ trait FFTProcessable(Movable,Copyable, ImplicitlyDestructible):
     def get_messages(mut self) -> None:
         return None
 
-struct FFTProcess[T: FFTProcessable, ifft: Bool = True,input_window_shape: Int = WindowType.hann, output_window_shape: Int = WindowType.hann](Movable,Copyable):
+struct FFTProcess[T: FFTProcessable, ifft: Bool = True,input_window_shape: WindowType = WindowType.hann, output_window_shape: WindowType = WindowType.hann](Movable,Copyable):
     """Create an FFTProcess for audio manipulation in the frequency domain.
 
     Parameters:

--- a/mmm_audio/FFT_Processes.mojo
+++ b/mmm_audio/FFT_Processes.mojo
@@ -20,7 +20,7 @@ struct HilbertWindow(ComplexFFTProcessable):
         for i in range(1, self.window_size):
             complex[i] *= ComplexSIMD[DType.float64, 1](math.cos(self.radians), math.sin(self.radians))
 
-struct Hilbert[window_type: Int = WindowType.sine](Movable, Copyable):
+struct Hilbert[window_type: WindowType = WindowType.sine](Movable, Copyable):
     var world: World
     var hilbert: ComplexFFTProcess[HilbertWindow,True,Self.window_type,Self.window_type]
     var window_size: Int

--- a/mmm_audio/FFTs.mojo
+++ b/mmm_audio/FFTs.mojo
@@ -300,7 +300,7 @@ struct RealFFT[num_chans: Int = 1](Copyable, Movable):
         return freqs^
 
     @staticmethod
-    def buf_analysis[input_window_shape: Int = WindowType.hann](buf: Buffer, chan: Int,start_frame: Int, var num_frames: Int, window_size: Int, hop_size: Int) -> Tuple[List[List[Float64]], List[List[Float64]]]:
+    def buf_analysis[input_window_shape: WindowType = WindowType.hann](buf: Buffer, chan: Int,start_frame: Int, var num_frames: Int, window_size: Int, hop_size: Int) -> Tuple[List[List[Float64]], List[List[Float64]]]:
         """Compute the Short-Time Fourier Transform (STFT) of a buffer.
 
         Parameters:

--- a/mmm_audio/MBufAnalysisBridge.mojo
+++ b/mmm_audio/MBufAnalysisBridge.mojo
@@ -237,7 +237,7 @@ struct MBufAnalysis:
         return result^
     
     @staticmethod
-    def fft_process[T: GetFloat64Featurable & FFTProcessable,//,input_win: Int = WindowType.hann](mut analyzer: T, buf: Buffer, chan: Int, start_frame: Int, var num_frames: Int, window_size: Int, hop_size: Int) raises -> List[List[Float64]]:
+    def fft_process[T: GetFloat64Featurable & FFTProcessable,//,input_win: WindowType = WindowType.hann](mut analyzer: T, buf: Buffer, chan: Int, start_frame: Int, var num_frames: Int, window_size: Int, hop_size: Int) raises -> List[List[Float64]]:
         result = List[List[Float64]]()
         frame: Int = start_frame
         if num_frames < 0:

--- a/mmm_audio/MMMWorld_Module.mojo
+++ b/mmm_audio/MMMWorld_Module.mojo
@@ -154,45 +154,56 @@ struct Interp(Equatable, ImplicitlyCopyable):
     comptime lagrange4 = Interp(4)
     comptime sinc = Interp(5)
 
+    @doc_hidden
     def __eq__(self, other: Self) -> Bool:
         return self._value == other._value
 
+    @doc_hidden
     def __ne__(self, other: Self) -> Bool:
         return not (self == other)
 
-struct WindowType:
+@fieldwise_init
+struct WindowType(Equatable, ImplicitlyCopyable):
     """Window types for predefined windows found in world[].windows.
 
     Specify a window type by typing it explicitly.
-    For example, to specify a hann window, one could use the number `1`, 
-    but it is clearer to type `WindowType.hann`.
 
-    | Window Type         | Value |
-    | ------------------- | ----- |
-    | WindowType.none     | -1    |
-    | WindowType.rect     | 0     |
-    | WindowType.hann     | 1     |
-    | WindowType.hamming  | 2     |
-    | WindowType.blackman | 3     |
-    | WindowType.kaiser   | 4     |
-    | WindowType.sine     | 5     |
-    | WindowType.tri      | 6     |
-    | WindowType.pan2     | 7     |
-    | WindowType.gaussian | 8     |
-    | WindowType.user_defined | 9 | 
+    | Window Type         | 
+    | ------------------- |
+    | WindowType.none     | 
+    | WindowType.rect     | 
+    | WindowType.hann     | 
+    | WindowType.hamming  | 
+    | WindowType.blackman | 
+    | WindowType.kaiser   | 
+    | WindowType.sine     | 
+    | WindowType.tri      | 
+    | WindowType.pan2     | 
+    | WindowType.gaussian | 
+    | WindowType.user_defined |
     """
 
-    comptime none: Int = -1
-    comptime rect: Int = 0
-    comptime hann: Int = 1
-    comptime hamming: Int = 2
-    comptime blackman: Int = 3
-    comptime kaiser: Int = 4
-    comptime sine: Int = 5
-    comptime tri: Int = 6
-    comptime pan2: Int = 7
-    comptime gaussian: Int = 8
-    comptime user_defined: Int = 9
+    var _value: Int
+
+    comptime none = WindowType(0)
+    comptime rect = WindowType(1)
+    comptime hann = WindowType(2)
+    comptime hamming = WindowType(3)
+    comptime blackman = WindowType(4)
+    comptime kaiser = WindowType(5)
+    comptime sine = WindowType(6)
+    comptime tri = WindowType(7)
+    comptime pan2 = WindowType(8)
+    comptime gaussian = WindowType(9)
+    comptime user_defined = WindowType(10)
+
+    @doc_hidden
+    def __eq__(self, other: Self) -> Bool:
+        return self._value == other._value
+
+    @doc_hidden
+    def __ne__(self, other: Self) -> Bool:
+        return not (self == other)
 
 struct OscType:
     """Oscillator types for selecting waveform types.

--- a/mmm_audio/Polyphony.mojo
+++ b/mmm_audio/Polyphony.mojo
@@ -326,15 +326,15 @@ trait GrainObject(PolyObject):
         """An __init__ with this layout must be implemented for the GrainObject trait."""
         ...
 
-    def next_2[num_buf_chans: Int, num_playback_chans: Int = 2, win_type: Int = WindowType.hann, custom_curve: Int = WindowType.none, bWrap: Bool = False](mut self, buffer: SIMDBuffer[num_buf_chans]) -> MFloat[2]:
+    def next_2[num_buf_chans: Int, num_playback_chans: Int = 2, win_type: WindowType = WindowType.hann, custom_curve: WindowType = WindowType.none, bWrap: Bool = False](mut self, buffer: SIMDBuffer[num_buf_chans]) -> MFloat[2]:
         """This is the function to create if you want to output 2 channels using pan2 or pan_stereo."""
         return 0.0
 
-    def next_az[num_buf_chans: Int, num_out_chans: Int, win_type: Int = WindowType.hann, custom_curve: Int = WindowType.none, bWrap: Bool = False](mut self, buffer: SIMDBuffer[num_buf_chans], buffer_chan: Int = 0, num_speakers: Int = 2, width: Float64 = 2.0, orientation: Float64 = 0.5) -> MFloat[num_out_chans]:
+    def next_az[num_buf_chans: Int, num_out_chans: Int, win_type: WindowType = WindowType.hann, custom_curve: WindowType = WindowType.none, bWrap: Bool = False](mut self, buffer: SIMDBuffer[num_buf_chans], buffer_chan: Int = 0, num_speakers: Int = 2, width: Float64 = 2.0, orientation: Float64 = 0.5) -> MFloat[num_out_chans]:
         """This is the function to create if you want to output more than 2 channels using azimuth panning. This will only pan 1 buffer channel."""
         return 0.0
 
-    def next_all[num_chans: Int, win_type: Int = WindowType.hann, custom_curve: Int = WindowType.none, bWrap: Bool = False](mut self, buffer: SIMDBuffer[num_chans]) -> MFloat[num_chans]:
+    def next_all[num_chans: Int, win_type: WindowType = WindowType.hann, custom_curve: WindowType = WindowType.none, bWrap: Bool = False](mut self, buffer: SIMDBuffer[num_chans]) -> MFloat[num_chans]:
         """This is the function to create if you want to output all channels of the buffer with no panning."""
         return 0.0
 
@@ -432,7 +432,7 @@ struct GrainAll(GrainObject):
         self.gain = gain
         self.pan = pan
 
-    def next_all[num_chans: Int, win_type: Int = WindowType.hann, custom_curve: Int = WindowType.none, bWrap: Bool = False](mut self, buffer: SIMDBuffer[num_chans]) -> MFloat[num_chans]:
+    def next_all[num_chans: Int, win_type: WindowType = WindowType.hann, custom_curve: WindowType = WindowType.none, bWrap: Bool = False](mut self, buffer: SIMDBuffer[num_chans]) -> MFloat[num_chans]:
         """Get the next sample of the grain. This function returns all channels of the buffer with no panning.
 
         Parameters:
@@ -519,7 +519,7 @@ struct Grain(GrainObject):
         self.grain.set_vals(rate, start_frame, duration, pan, gain)
         self.start_chan = start_chan
 
-    def next_2[num_buf_chans: Int, num_playback_chans: Int = 2, win_type: Int = WindowType.hann, custom_curve: Int = WindowType.none, bWrap: Bool = False](mut self, buffer: SIMDBuffer[num_buf_chans]) -> MFloat[2]:
+    def next_2[num_buf_chans: Int, num_playback_chans: Int = 2, win_type: WindowType = WindowType.hann, custom_curve: WindowType = WindowType.none, bWrap: Bool = False](mut self, buffer: SIMDBuffer[num_buf_chans]) -> MFloat[2]:
         """Get the next sample of the grain as a stereo signal with panning.
 
         Parameters:
@@ -542,7 +542,7 @@ struct Grain(GrainObject):
             panned = pan_stereo(MFloat[2](sample[self.start_chan], sample[(self.start_chan + 1) % buffer.get_num_chans()]), self.grain.pan) 
             return panned
 
-    def next_az[num_buf_chans: Int, num_out_chans: Int = 2, win_type: Int = WindowType.hann, custom_curve: Int = WindowType.none, bWrap: Bool = False](mut self, buffer: SIMDBuffer[num_buf_chans], buffer_chan: Int = 0, num_speakers: Int = 2, width: Float64 = 2.0, orientation: Float64 = 0.5) -> MFloat[num_out_chans]:
+    def next_az[num_buf_chans: Int, num_out_chans: Int = 2, win_type: WindowType = WindowType.hann, custom_curve: WindowType = WindowType.none, bWrap: Bool = False](mut self, buffer: SIMDBuffer[num_buf_chans], buffer_chan: Int = 0, num_speakers: Int = 2, width: Float64 = 2.0, orientation: Float64 = 0.5) -> MFloat[num_out_chans]:
         """Get the next sample of the grain as a multi-channel signal with azimuth panning. This only pans 1 channel of the buffer, specified by buffer_chan. See next_2 for param/arg descriptions and pan_az for details on the panning parameters.
         """
         var sample = self.grain.next_all[win_type=win_type, bWrap=bWrap](buffer)
@@ -551,13 +551,13 @@ struct Grain(GrainObject):
 
         return panned
 
-    def next_all[num_chans: Int, win_type: Int = WindowType.hann, custom_curve: Int = WindowType.none, bWrap: Bool = False](mut self, buffer: SIMDBuffer[num_chans]) -> MFloat[num_chans]:
+    def next_all[num_chans: Int, win_type: WindowType = WindowType.hann, custom_curve: WindowType = WindowType.none, bWrap: Bool = False](mut self, buffer: SIMDBuffer[num_chans]) -> MFloat[num_chans]:
         """Get the next sample of the grain with no panning. This returns all channels of the buffer. See next_2 for param/arg descriptions.
         """
         var sample = self.grain.next_all[win_type=win_type, bWrap=bWrap](buffer)
         return sample
 
-struct TGrains[T: GrainObject = Grain[], win_type: Int = WindowType.hann, custom_curve: Int = WindowType.none](Movable, Copyable):
+struct TGrains[T: GrainObject = Grain[], win_type: WindowType = WindowType.hann, custom_curve: WindowType = WindowType.none](Movable, Copyable):
     """
     Triggered granular synthesis. Each trigger starts a new grain.
     """
@@ -695,7 +695,7 @@ struct TGrains[T: GrainObject = Grain[], win_type: Int = WindowType.hann, custom
                 out += self.grains[i].next_all[win_type=Self.win_type, custom_curve=Self.custom_curve, bWrap=bWrap](buffer)
         return out * gain
 
-struct PitchShift[num_chans: Int = 1, win_type: Int = WindowType.hann](Movable, Copyable):
+struct PitchShift[num_chans: Int = 1, win_type: WindowType = WindowType.hann](Movable, Copyable):
     """
     An N channel granular pitchshifter. Each channel is processed in parallel.
 

--- a/mmm_audio/Windows_Module.mojo
+++ b/mmm_audio/Windows_Module.mojo
@@ -23,7 +23,7 @@ struct Windows(Movable, Copyable):
         self.pan2 = pan2_window(256)
         self.gaussian = gaussian_window(self.size)
 
-    def at_phase[num_chans: Int, window_type: Int, interp: Interp = Interp.none](self, world: World, phase: MFloat[num_chans], prev_phase: MFloat[num_chans] = 0.0) -> MFloat[num_chans]:
+    def at_phase[num_chans: Int, window_type: WindowType, interp: Interp = Interp.none](self, world: World, phase: MFloat[num_chans], prev_phase: MFloat[num_chans] = 0.0) -> MFloat[num_chans]:
         """Get window value at given phase (0.0 to 1.0) for specified window type."""
 
         out = MFloat[num_chans](0.0)
@@ -58,7 +58,7 @@ struct Windows(Movable, Copyable):
         return out
 
     @staticmethod
-    def make_window[window_type: Int](size: Int, beta: Float64 = 5.0) -> List[Float64]:
+    def make_window[window_type: WindowType](size: Int, beta: Float64 = 5.0) -> List[Float64]:
         """Generate a window of specified type and size.
         
         Parameters:


### PR DESCRIPTION
This PR implements the WindowType Enum (or, Modular-endorsed Mojo-style Enum). This makes code more readable, encourages clarity, and avoids user foot-guns.

Any user code that was already using the faux enums (e.g., WindowType.hann) will still work excellently. Any user code that was using Int to specify WindowType will need to now use the enum.

This addresses issue #160, however before it can be closed the full migration will also include OscType and possibly also an Enum for osc_index since that is not really an "Int", but in fact a selection of an option.