### PR TITLE
TimesOversampling Enum

### DIFF
--- a/examples/BenjolinExample.mojo
+++ b/examples/BenjolinExample.mojo
@@ -13,10 +13,10 @@ struct Benjolin(Movable, Copyable):
     var m: Messenger
     var feedback: Float64
     var rungler: Float64
-    var tri1: Osc[interp=Interp.quad,os_index=1]
-    var tri2: Osc[interp=Interp.quad,os_index=1]
-    var pulse1: Osc[interp=Interp.quad,os_index=1]
-    var pulse2: Osc[interp=Interp.quad,os_index=1]
+    var tri1: Osc[interp=Interp.quad,ov_samp = TimesOversampling.x2]
+    var tri2: Osc[interp=Interp.quad,ov_samp = TimesOversampling.x2]
+    var pulse1: Osc[interp=Interp.quad,ov_samp = TimesOversampling.x2]
+    var pulse2: Osc[interp=Interp.quad,ov_samp = TimesOversampling.x2]
     var delays: List[Delay[1,Interp.cubic]]
     var latches: List[Latch[]]
     var filters: List[SVF[]]
@@ -44,10 +44,10 @@ struct Benjolin(Movable, Copyable):
         self.m = Messenger(self.world)
         self.feedback = 0.0
         self.rungler = 0.0
-        self.tri1 = Osc[interp=Interp.quad,os_index=1](self.world)
-        self.tri2 = Osc[interp=Interp.quad,os_index=1](self.world)
-        self.pulse1 = Osc[interp=Interp.quad,os_index=1](self.world)
-        self.pulse2 = Osc[interp=Interp.quad,os_index=1](self.world)
+        self.tri1 = Osc[interp=Interp.quad,ov_samp = TimesOversampling.x2](self.world)
+        self.tri2 = Osc[interp=Interp.quad,ov_samp = TimesOversampling.x2](self.world)
+        self.pulse1 = Osc[interp=Interp.quad,ov_samp = TimesOversampling.x2](self.world)
+        self.pulse2 = Osc[interp=Interp.quad,ov_samp = TimesOversampling.x2](self.world)
         self.delays = List[Delay[1,Interp.cubic]](capacity=8)
         self.latches = List[Latch[]](capacity=8)
         self.filters = List[SVF[]](capacity=9)

--- a/examples/BuchlaWaveFolder_AD.mojo
+++ b/examples/BuchlaWaveFolder_AD.mojo
@@ -4,7 +4,7 @@ struct BuchlaWaveFolder_AD(Movable, Copyable):
     var world: World  
     var osc: Osc[2]
     var lag: Lag[1]
-    var b259: BuchlaWavefolder[2, 1]
+    var b259: BuchlaWavefolder[2, TimesOversampling.x2]
     var m: Messenger
 
 
@@ -13,7 +13,7 @@ struct BuchlaWaveFolder_AD(Movable, Copyable):
         # for efficiency we set the interpolation and oversampling in the constructor
         self.osc = Osc[2](world)
         self.lag = Lag(world, 0.1)
-        self.b259 = BuchlaWavefolder[2, 1](world)
+        self.b259 = BuchlaWavefolder[2, TimesOversampling.x2](world)
         self.m = Messenger(world)
 
     def next(mut self) -> MFloat[2]:

--- a/examples/ChowningFM.mojo
+++ b/examples/ChowningFM.mojo
@@ -3,8 +3,8 @@ from mmm_audio import *
 struct ChowningFM(Movable, Copyable):
     var world: World # pointer to the MMMWorld
     var m: Messenger
-    var c_osc: Osc[1,Interp.linear,1]  # Carrier oscillator
-    var m_osc: Osc[1,Interp.linear,1]  # Modulator oscillator
+    var c_osc: Osc[1,Interp.linear,TimesOversampling.x2]  # Carrier oscillator
+    var m_osc: Osc[1,Interp.linear,TimesOversampling.x2]  # Modulator oscillator
     var index_env: Env
     var amp_env: Env
     var cfreq: Float64
@@ -14,8 +14,8 @@ struct ChowningFM(Movable, Copyable):
     def __init__(out self, world: World):
         self.world = world
         self.m = Messenger(self.world)
-        self.c_osc = Osc[1,Interp.linear,1](self.world)
-        self.m_osc = Osc[1,Interp.linear,1](self.world)
+        self.c_osc = Osc[1,Interp.linear,TimesOversampling.x2](self.world)
+        self.m_osc = Osc[1,Interp.linear,TimesOversampling.x2](self.world)
         self.index_env = Env(self.world)
         self.amp_env = Env(self.world)
         self.cfreq = 200.0

--- a/examples/DefaultGraph.mojo
+++ b/examples/DefaultGraph.mojo
@@ -2,7 +2,7 @@ from mmm_audio import *
 
 struct Default_Synth(Movable, Copyable):
     var world: World  
-    var osc: Osc[1,Interp.sinc,1]
+    var osc: Osc[1,Interp.sinc,TimesOversampling.x2]
     var filt: SVF[1]
     var messenger: Messenger
     var freq: Float64
@@ -10,7 +10,7 @@ struct Default_Synth(Movable, Copyable):
 
     def __init__(out self, world: World):
         self.world = world
-        self.osc = Osc[1,Interp.sinc,1](self.world)
+        self.osc = Osc[1,Interp.sinc,TimesOversampling.x2](self.world)
         self.filt = SVF[1](self.world)
         self.messenger = Messenger(self.world)
         self.freq = 440.0

--- a/examples/FM4.mojo
+++ b/examples/FM4.mojo
@@ -3,15 +3,14 @@ from mmm_audio import *
 struct FM4(Movable, Copyable):
     var world: World
 
-    comptime os_index = 2
-    comptime times_oversampling = 1 << Self.os_index
+    comptime times_oversampling = TimesOversampling.x4
 
     var over: Oversampling[2, Self.times_oversampling]
 
-    var osc0: Osc[1, Interp.sinc, 0]
-    var osc1: Osc[1, Interp.sinc, 0]
-    var osc2: Osc[1, Interp.sinc, 0]
-    var osc3: Osc[1, Interp.sinc, 0]
+    var osc0: Osc[1, Interp.sinc]
+    var osc1: Osc[1, Interp.sinc]
+    var osc2: Osc[1, Interp.sinc]
+    var osc3: Osc[1, Interp.sinc]
 
     var osc0_freq: MFloat[1]
     var osc1_freq: MFloat[1]
@@ -33,16 +32,16 @@ struct FM4(Movable, Copyable):
 
         self.over = Oversampling[2, Self.times_oversampling](world)
 
-        self.osc0 = Osc[1, Interp.sinc, 0](world)
-        self.osc1 = Osc[1, Interp.sinc, 0](world)
-        self.osc2 = Osc[1, Interp.sinc, 0](world)
-        self.osc3 = Osc[1, Interp.sinc, 0](world)
+        self.osc0 = Osc[1, Interp.sinc](world)
+        self.osc1 = Osc[1, Interp.sinc](world)
+        self.osc2 = Osc[1, Interp.sinc](world)
+        self.osc3 = Osc[1, Interp.sinc](world)
 
         # adjust the phase multipliers for oversampling
-        self.osc0.phasor.freq_mul /= Self.times_oversampling
-        self.osc1.phasor.freq_mul /= Self.times_oversampling
-        self.osc2.phasor.freq_mul /= Self.times_oversampling
-        self.osc3.phasor.freq_mul /= Self.times_oversampling
+        self.osc0.set_oversampling(Self.times_oversampling)
+        self.osc1.set_oversampling(Self.times_oversampling)
+        self.osc2.set_oversampling(Self.times_oversampling)
+        self.osc3.set_oversampling(Self.times_oversampling)
         
         # set the initial frequencies
         self.osc0_freq = 220.0
@@ -88,7 +87,7 @@ struct FM4(Movable, Copyable):
         self.m.update("osc_frac3", self.osc_frac[3])
 
         # the oversampling loop
-        for _ in range(Self.times_oversampling):
+        for _ in range(Self.times_oversampling.times):
 
             fm_0 = self.fb[1] * self.osc0_mul[0] + self.fb[2] * self.osc0_mul[1]
             osc0 = self.osc0.next_basic_waveforms[OscType.sine, OscType.triangle, OscType.saw, OscType.square](self.osc0_freq + fm_0, osc_frac=self.osc_frac[0])

--- a/examples/FeedbackDelays.mojo
+++ b/examples/FeedbackDelays.mojo
@@ -5,7 +5,7 @@ struct DelaySynth(Movable, Copyable):
 
     var buf: Buffer
     var playBuf: Play
-    var delays: FB_Delay[2, Interp.lagrange4, True, 1]  # FB_Delay for feedback delay effect - notice we are using ADAA and Oversampling in the internal Tanh funciton.
+    var delays: FB_Delay[2, Interp.lagrange4, True, TimesOversampling.x2]  # FB_Delay for feedback delay effect - notice we are using ADAA and Oversampling in the internal Tanh funciton.
     var lag: Lag[2]
 
     def __init__(out self, world: World):
@@ -13,7 +13,7 @@ struct DelaySynth(Movable, Copyable):
         self.buf = Buffer.load("resources/Shiverer.wav")
         self.playBuf = Play(self.world) 
         # FB_Delay is initialized as 2 channel
-        self.delays = FB_Delay[2, Interp.lagrange4, True, 1](self.world, 1.0) 
+        self.delays = FB_Delay[2, Interp.lagrange4, True, TimesOversampling.x2](self.world, 1.0) 
 
         self.lag = Lag[2](self.world, 0.5)  # Initialize Lag with a default time constant
 

--- a/examples/MidiSequencer.mojo
+++ b/examples/MidiSequencer.mojo
@@ -8,7 +8,7 @@ struct TrigSynthVoice(PolyObject):
     var world: World  # Pointer to the MMMWorld instance
     var env: Env
     var mod: Osc[]
-    var car: Osc[1, Interp.linear, 0]
+    var car: Osc[1, Interp.linear]
     var sub: Osc[]
     var bend_mul: Float64
     var note: List[Float64]
@@ -25,7 +25,7 @@ struct TrigSynthVoice(PolyObject):
     def __init__(out self, world: World):
         self.world = world
         self.mod = Osc(self.world)
-        self.car = Osc[1, Interp.linear, 0](self.world)
+        self.car = Osc[1, Interp.linear](self.world)
         self.sub = Osc(self.world)
         self.env = Env(self.world)
         self.env.params = EnvParams([0.0, 1.0, 0.75, 0.75, 0.0], [0.01, 0.1, 0.2, 0.5], [1.0])

--- a/examples/MoogPops.mojo
+++ b/examples/MoogPops.mojo
@@ -7,7 +7,7 @@ comptime how_many = 16
 struct MoogPops(Movable, Copyable):
     var world: World  
     var dusts: Dust[how_many]
-    var filts: VAMoogLadder[how_many, 4]
+    var filts: VAMoogLadder[how_many, TimesOversampling.x16] # 4-pole Moog ladder filter, 16x oversampling
     var m: Messenger
     var t_exp_rand: TExpRand[how_many]
     var t_rand: TRand[how_many]
@@ -17,7 +17,7 @@ struct MoogPops(Movable, Copyable):
     def __init__(out self, world: World):
         self.world = world
         self.dusts = Dust[how_many](world)
-        self.filts = VAMoogLadder[how_many, 4](world)
+        self.filts = VAMoogLadder[how_many, TimesOversampling.x16](world)
         self.m = Messenger(world)
         self.t_exp_rand = TExpRand[how_many]()
         self.t_rand = TRand[how_many]()

--- a/examples/PAF_example.mojo
+++ b/examples/PAF_example.mojo
@@ -3,7 +3,7 @@ from mmm_audio import *
 struct PAF_example(Copyable, Movable):
     var world: World
 
-    var paf: PAF[2, Interp.linear, 1, wrap_gaussian=True] # try changing wrap_gaussian to True
+    var paf: PAF[2, Interp.linear, TimesOversampling.x2, wrap_gaussian=True] # try changing wrap_gaussian to True
 
     var fund: MFloat[]
     var center: MFloat[]
@@ -17,7 +17,7 @@ struct PAF_example(Copyable, Movable):
     def __init__(out self, world: World):
         self.world = world
 
-        self.paf = PAF[2, Interp.linear, 1, wrap_gaussian=True](world)# try changing wrap_gaussian to True
+        self.paf = PAF[2, Interp.linear, TimesOversampling.x2, wrap_gaussian=True](world)# try changing wrap_gaussian to True
 
         self.fund = 73.0
         self.center = 440.0

--- a/examples/PAF_example.py
+++ b/examples/PAF_example.py
@@ -1,8 +1,7 @@
-if True:
-    from mmm_python import *
-    from random import getstate, setstate, randint
-    mmm_audio = MMMAudio(128, 2, 2, graph_name="PAF_example", package_name="examples")
-    mmm_audio.start_audio()
+from mmm_python import *
+from random import getstate, setstate, randint
+mmm_audio = MMMAudio(128, graph_name="PAF_example", package_name="examples", in_device=None, audio_init_timeout=60)
+mmm_audio.start_audio()
 
 mmm_audio.send_float("center_freq", 200)
 mmm_audio.send_float("bandwidth", 800)

--- a/examples/ParallelGraphs.mojo
+++ b/examples/ParallelGraphs.mojo
@@ -2,7 +2,7 @@ from mmm_audio import *
 
 struct ParallelGraphs(Movable, Copyable):
     var world: World  
-    var osc: Osc[1,Interp.sinc,1]
+    var osc: Osc[1,Interp.sinc,TimesOversampling.x2]
     var filt: SVF[1]
     var messenger: Messenger
     var freq: Float64
@@ -10,7 +10,7 @@ struct ParallelGraphs(Movable, Copyable):
 
     def __init__(out self, world: World):
         self.world = world
-        self.osc = Osc[1,Interp.sinc,1](self.world)
+        self.osc = Osc[1,Interp.sinc,TimesOversampling.x2](self.world)
         self.filt = SVF[1](self.world)
         self.messenger = Messenger(self.world)
         self.freq = 440.0

--- a/examples/PlayExample.mojo
+++ b/examples/PlayExample.mojo
@@ -10,7 +10,7 @@ struct BufSynth(Movable, Copyable):
     var play_buf: Play
     var play_rate: Float64
     
-    var moog: VAMoogLadder[num_chans, 1] # 2 channels, os_index == 1 (2x oversampling)
+    var moog: VAMoogLadder[num_chans, TimesOversampling.x2] # 2 channels, ov_samp == 1 (2x oversampling)
     var lpf_freq: Float64
     var lpf_freq_lag: Lag[]
     var messenger: Messenger
@@ -30,7 +30,7 @@ struct BufSynth(Movable, Copyable):
 
         self.play_buf = Play(self.world)
 
-        self.moog = VAMoogLadder[num_chans, 1](self.world)
+        self.moog = VAMoogLadder[num_chans, TimesOversampling.x2](self.world)
         self.lpf_freq = 20000.0
         self.lpf_freq_lag = Lag(self.world, 0.1)
 

--- a/examples/PlayRecExample.mojo
+++ b/examples/PlayRecExample.mojo
@@ -13,7 +13,7 @@ struct PlayRecExample(Movable, Copyable):
     var recorder: Recorder[2]
     var record_bool: Bool
     
-    var moog: VAMoogLadder[num_chans, 1] # 2 channels, os_index == 1 (2x oversampling)
+    var moog: VAMoogLadder[num_chans, TimesOversampling.x2] # 2 channels, ov_samp == 1 (2x oversampling)
     var lpf_freq: Float64
     var lpf_freq_lag: Lag[]
     var messenger: Messenger
@@ -37,7 +37,7 @@ struct PlayRecExample(Movable, Copyable):
 
         self.play_buf = Play(self.world)
 
-        self.moog = VAMoogLadder[num_chans, 1](self.world)
+        self.moog = VAMoogLadder[num_chans, TimesOversampling.x2](self.world)
         self.lpf_freq = 20000.0
         self.lpf_freq_lag = Lag(self.world, 0.1)
 

--- a/examples/TorchMlp.mojo
+++ b/examples/TorchMlp.mojo
@@ -7,8 +7,8 @@ comptime model_out_size = 16  # Define the output size of the model
 # THE SYNTH - is imported from TorchSynth.mojo in this directory
 struct TorchSynth(Movable, Copyable):
     var world: World  # Pointer to the MMMWorld instance
-    var osc1: Osc[1, Interp.sinc, 1]
-    var osc2: Osc[1, Interp.sinc, 1]
+    var osc1: Osc[1, Interp.sinc, TimesOversampling.x2]  # Oscillator 1 with interpolation and oversampling
+    var osc2: Osc[1, Interp.sinc, TimesOversampling.x2]  # Oscillator 2 with interpolation and oversampling
 
     var model: MLP[2, model_out_size]  # Instance of the MLP model - 2 inputs, model_out_size outputs
     var lags: Lags[model_out_size]  # A Lags (Lags processed in parallel) for smoothing the model outputs
@@ -28,8 +28,8 @@ struct TorchSynth(Movable, Copyable):
 
     def __init__(out self, world: World):
         self.world = world
-        self.osc1 = Osc[1, Interp.sinc, 1](self.world)
-        self.osc2 = Osc[1, Interp.sinc, 1](self.world)
+        self.osc1 = Osc[1, Interp.sinc, TimesOversampling.x2](self.world)
+        self.osc2 = Osc[1, Interp.sinc, TimesOversampling.x2](self.world)
 
         # load the trained model
         self.model = MLP(self.world,"examples/nn_trainings/model_traced.pt", "mlp1", trig_rate=25.0)

--- a/examples/VariableOsc.mojo
+++ b/examples/VariableOsc.mojo
@@ -6,7 +6,7 @@ struct VariableOsc(Movable, Copyable):
     # so here we have sinc interpolation with 2x oversampling
     # var osc: Osc[1,2,1]
     # var lag: Lag[1]
-    var osc: Osc[2,Interp.sinc,os_index=1]
+    var osc: Osc[2,Interp.sinc,ov_samp = TimesOversampling.x2]
     var lag: Lag[2]
     var m: Messenger
     var x: Float64
@@ -17,7 +17,7 @@ struct VariableOsc(Movable, Copyable):
     def __init__(out self, world: World):
         self.world = world
         # for efficiency we set the interpolation and oversampling in the constructor
-        self.osc = Osc[2,Interp.sinc,os_index=1](self.world)
+        self.osc = Osc[2,Interp.sinc,ov_samp = TimesOversampling.x2](self.world)
         self.lag = Lag[2](self.world, 0.1)
         self.m = Messenger(self.world)
         self.x = 0.0

--- a/examples/WavetableOsc.mojo
+++ b/examples/WavetableOsc.mojo
@@ -1,7 +1,7 @@
 from mmm_audio import *
 
 struct OscVoice(Movable, Copyable):
-    var osc: Osc[1,Interp.quad,1]
+    var osc: Osc[1,Interp.quad,TimesOversampling.x2]
     var tri: LFOsc[]
     var world: World
     var env: ASREnv
@@ -11,7 +11,7 @@ struct OscVoice(Movable, Copyable):
     var messenger: Messenger
 
     def __init__(out self, world: World, name_space: String = ""):
-        self.osc = Osc[1,Interp.quad,1](world)
+        self.osc = Osc[1,Interp.quad,TimesOversampling.x2](world)
         self.tri = LFOsc(world)
         self.env = ASREnv(world)
         self.gate = False
@@ -36,7 +36,7 @@ struct WavetableOsc(Movable, Copyable):
     var messenger: Messenger
     var filter_cutoff: Float64
     var filter_resonance: Float64
-    var moog_filter: VAMoogLadder[1,1]
+    var moog_filter: VAMoogLadder[1,TimesOversampling.x2]
 
     def __init__(out self, world: World):
         self.world = world
@@ -50,7 +50,7 @@ struct WavetableOsc(Movable, Copyable):
         self.messenger = Messenger(self.world)
         self.filter_cutoff = 20000.0
         self.filter_resonance = 0.5
-        self.moog_filter = VAMoogLadder[1,1](self.world)
+        self.moog_filter = VAMoogLadder[1,TimesOversampling.x2](self.world)
 
     def loadBuffer(mut self):
         self.buffer = Buffer.load(self.file_name, num_wavetables=self.wavetables_per_channel)

--- a/examples/WavetableOscSIMD.mojo
+++ b/examples/WavetableOscSIMD.mojo
@@ -1,7 +1,7 @@
 from mmm_audio import *
 
 struct OscVoice(PolyObject):
-    var osc: Osc[1,Interp.sinc,0]
+    var osc: Osc[1,Interp.sinc]
     var tri: LFOsc[]
     var world: World
     var env: ASREnv
@@ -21,7 +21,7 @@ struct OscVoice(PolyObject):
         self.gate = gate
 
     def __init__(out self, world: World, name_space: String = ""):
-        self.osc = Osc[1,Interp.sinc,0](world)
+        self.osc = Osc[1,Interp.sinc](world)
         self.tri = LFOsc(world)
         self.env = ASREnv(world)
         self.gate = False
@@ -52,7 +52,7 @@ struct WavetableOscSIMD(Movable, Copyable):
     var messenger: Messenger
     var filter_cutoff: Float64
     var filter_resonance: Float64
-    var moog_filter: VAMoogLadder[1,1]
+    var moog_filter: VAMoogLadder[1,TimesOversampling.x2]
 
 
     def __init__(out self, world: World):
@@ -67,7 +67,7 @@ struct WavetableOscSIMD(Movable, Copyable):
         self.messenger = Messenger(self.world)
         self.filter_cutoff = 20000.0
         self.filter_resonance = 0.5
-        self.moog_filter = VAMoogLadder[1,1](self.world)
+        self.moog_filter = VAMoogLadder[1,TimesOversampling.x2](self.world)
 
     def loadBuffer(mut self):
         self.buffer = SIMDBuffer[Self.wavetables_per_channel].load(self.file_name, num_wavetables=self.wavetables_per_channel)

--- a/examples/tests/TestHardClipADAA.mojo
+++ b/examples/tests/TestHardClipADAA.mojo
@@ -8,13 +8,13 @@ struct TestHardClipADAA[num_chans: Int = 2](Movable, Copyable):
     var world: World
     var osc: Osc[]
     var lag: Lag[]
-    var clip: SoftClipAD[1,4]
+    var clip: SoftClipAD[1,TimesOversampling.x16]
     var overdrive: TanhAD[Self.num_chans]
 
     def __init__(out self, world: World):
         self.world = world
         self.osc = Osc(world)
-        self.clip = SoftClipAD[1,4](world)
+        self.clip = SoftClipAD[1,TimesOversampling.x16](world)
         self.overdrive = TanhAD[Self.num_chans](world)
         self.lag = Lag(world)
 

--- a/examples/tests/TestOscOversampling.mojo
+++ b/examples/tests/TestOscOversampling.mojo
@@ -6,10 +6,10 @@ from mmm_audio import *
 struct TestOscOversampling(Movable, Copyable):
     var world: World
     var osc: Osc[]
-    var osc1: Osc[1,Interp.linear,1]
-    var osc2: Osc[1,Interp.linear,2]
-    var osc3: Osc[1,Interp.linear,3]
-    var osc4: Osc[1,Interp.linear,4]
+    var osc1: Osc[1,Interp.linear,TimesOversampling.x2]
+    var osc2: Osc[1,Interp.linear,TimesOversampling.x4]
+    var osc3: Osc[1,Interp.linear,TimesOversampling.x8]
+    var osc4: Osc[1,Interp.linear,TimesOversampling.x16]
     var which: Float64
     var messenger: Messenger
     var lag: Lag[]
@@ -17,10 +17,10 @@ struct TestOscOversampling(Movable, Copyable):
     def __init__(out self, world: World):
         self.world = world
         self.osc = Osc(world)
-        self.osc1 = Osc[1,Interp.linear,1](world)
-        self.osc2 = Osc[1,Interp.linear,2](world)
-        self.osc3 = Osc[1,Interp.linear,3](world)
-        self.osc4 = Osc[1,Interp.linear,4](world)
+        self.osc1 = Osc[1,Interp.linear,TimesOversampling.x2](world)
+        self.osc2 = Osc[1,Interp.linear,TimesOversampling.x4](world)
+        self.osc3 = Osc[1,Interp.linear,TimesOversampling.x8](world)
+        self.osc4 = Osc[1,Interp.linear,TimesOversampling.x16](world)
         self.which = 0.0
         self.messenger = Messenger(world)
         self.lag = Lag(world, 0.1)

--- a/examples/tests/TestUpsample.mojo
+++ b/examples/tests/TestUpsample.mojo
@@ -1,24 +1,24 @@
 
 from mmm_audio import *
 
-comptime times_oversample = 16
+comptime ov_samp = TimesOversampling.x16
 struct TestUpsample(Movable, Copyable):
     var world: World
     var osc: Osc[]
-    var upsampler: Upsampler[1, times_oversample]
+    var upsampler: Upsampler[1, ov_samp]
     var messenger: Messenger
 
     def __init__(out self, world: World):
         self.world = world
         self.osc = Osc(world)
-        self.upsampler = Upsampler[1, times_oversample](world)
+        self.upsampler = Upsampler[1, ov_samp](world)
         self.messenger = Messenger(world)
 
     def next(mut self) -> MFloat[2]:
 
         sample = self.osc.next[OscType.triangle](self.world[].mouse_y * 200.0 + 20.0)
         sample2 = 0.0
-        for i in range(times_oversample):
+        for i in range(ov_samp.times):
             sample2 = self.upsampler.next(sample, i)
 
         return MFloat[2](sample, sample2) * 0.2

--- a/examples/tests/TestVAMoogLadder.mojo
+++ b/examples/tests/TestVAMoogLadder.mojo
@@ -6,9 +6,9 @@ from mmm_audio import *
 struct TestVAMoogLadder[N: Int = 2](Movable, Copyable):
     var world: World
     var noise: WhiteNoise[Self.N]
-    var filt0: VAMoogLadder[Self.N, 0]
-    var filt2: VAMoogLadder[Self.N, 2]
-    var filt4: VAMoogLadder[Self.N, 4]
+    var filt0: VAMoogLadder[Self.N, TimesOversampling.none]  # 4-pole Moog ladder filter, no oversampling
+    var filt2: VAMoogLadder[Self.N, TimesOversampling.x4]
+    var filt4: VAMoogLadder[Self.N, TimesOversampling.x16]
     var m: Messenger
     var which: Float64
 
@@ -16,9 +16,9 @@ struct TestVAMoogLadder[N: Int = 2](Movable, Copyable):
     def __init__(out self, world: World):
         self.world = world
         self.noise = WhiteNoise[Self.N]()
-        self.filt0 = VAMoogLadder[Self.N, 0](world)
-        self.filt2 = VAMoogLadder[Self.N, 2](world)
-        self.filt4 = VAMoogLadder[Self.N, 4](world)
+        self.filt0 = VAMoogLadder[Self.N, TimesOversampling.none](world)
+        self.filt2 = VAMoogLadder[Self.N, TimesOversampling.x4](world)
+        self.filt4 = VAMoogLadder[Self.N, TimesOversampling.x16](world)
         self.m = Messenger(world)
         self.which = 0.0
 

--- a/examples/tests/WavetableOscSIMDStrings.mojo
+++ b/examples/tests/WavetableOscSIMDStrings.mojo
@@ -1,7 +1,7 @@
 from mmm_audio import *
 
 struct OscVoice(PolyObject):
-    var osc: Osc[1,Interp.sinc,0]
+    var osc: Osc[1,Interp.sinc]
     var tri: LFOsc[]
     var world: World
     var env: ASREnv
@@ -20,7 +20,7 @@ struct OscVoice(PolyObject):
         self.gate = gate
 
     def __init__(out self, world: World, name_space: String = ""):
-        self.osc = Osc[1,Interp.sinc,0](world)
+        self.osc = Osc[1,Interp.sinc](world)
         self.tri = LFOsc(world)
         self.env = ASREnv(world)
         self.gate = False
@@ -47,7 +47,7 @@ struct WavetableOscSIMDStrings(Movable, Copyable):
     var messenger: Messenger
     var filter_cutoff: Float64
     var filter_resonance: Float64
-    var moog_filter: VAMoogLadder[1,1]
+    var moog_filter: VAMoogLadder[1,TimesOversampling.x2]
     var poly: Poly
 
     def __init__(out self, world: World):
@@ -62,7 +62,7 @@ struct WavetableOscSIMDStrings(Movable, Copyable):
         self.messenger = Messenger(world)
         self.filter_cutoff = 20000.0
         self.filter_resonance = 0.5
-        self.moog_filter = VAMoogLadder[1,1](self.world)
+        self.moog_filter = VAMoogLadder[1,TimesOversampling.x2](self.world)
 
     def loadBuffer(mut self):
         self.buffer = SIMDBuffer[Self.wavetables_per_channel].load(self.file_name, num_wavetables=self.wavetables_per_channel)

--- a/mmm_audio/Delays.mojo
+++ b/mmm_audio/Delays.mojo
@@ -412,23 +412,23 @@ struct Allpass[num_chans: Int = 1, interp: Interp = Interp.linear](Tapable):
         return self.next(input, delay_time, feedback)
         
 
-struct FB_Delay[num_chans: Int = 1, interp: Interp = Interp.lagrange4, ADAA_dist: Bool = False, os_index: Int = 0](Tapable):
+struct FB_Delay[num_chans: Int = 1, interp: Interp = Interp.lagrange4, ADAA_dist: Bool = False, ov_samp: TimesOversampling = TimesOversampling.none](Tapable):
     """A feedback delay structured like a Comb filter, but with possible feedback coefficient above 1 due to an integrated tanh function.
     
-    By default, Anti-aliasing is disabled and no [oversampling](Oversampling.md) is applied, but this can be changed by setting the ADAA_dist and os_index template parameters.
+    By default, Anti-aliasing is disabled and no [oversampling](Oversampling.md) is applied, but this can be changed by setting the ADAA_dist and ov_samp template parameters.
     
     Parameters:
       num_chans: Size of the SIMD vector.
       interp: The interpolation method to use. See the struct [Interp](MMMWorld.md#struct-interp) for interpolation options.
       ADAA_dist: Whether to apply ADAA distortion to the feedback signal instead of standard tanh.
-      os_index: The [oversampling](Oversampling.md) index for ADAA distortion. 0 = no oversampling, 1 = 2x, 2 = 4x, 3 = 8x, 4 = 16x.
+      ov_samp: The [oversampling](Oversampling.md) index for ADAA distortion. 0 = no oversampling, 1 = 2x, 2 = 4x, 3 = 8x, 4 = 16x.
     """
 
     var world: World
     var delay: Delay[Self.num_chans, Self.interp]
     var dc: DCTrap[Self.num_chans]
     var fb: MFloat[Self.num_chans]
-    var tanh_ad: TanhAD[Self.num_chans, Self.os_index]
+    var tanh_ad: TanhAD[Self.num_chans, Self.ov_samp]
 
     def __init__(out self, world: World, max_delay_time: Float64 = 1.0):
       """Initialize the FB_Delay.
@@ -442,7 +442,7 @@ struct FB_Delay[num_chans: Int = 1, interp: Interp = Interp.lagrange4, ADAA_dist
         self.delay = Delay[Self.num_chans, Self.interp](self.world, max_delay_time)
         self.dc = DCTrap[Self.num_chans](self.world)
         self.fb = MFloat[Self.num_chans](0.0)
-        self.tanh_ad = TanhAD[Self.num_chans, Self.os_index](self.world)
+        self.tanh_ad = TanhAD[Self.num_chans, Self.ov_samp](self.world)
 
     def tap(mut self, delay_samps: MInt[Self.num_chans]) -> MFloat[Self.num_chans]:
         return self.delay.tap(delay_samps)

--- a/mmm_audio/Delays.mojo
+++ b/mmm_audio/Delays.mojo
@@ -421,7 +421,7 @@ struct FB_Delay[num_chans: Int = 1, interp: Interp = Interp.lagrange4, ADAA_dist
       num_chans: Size of the SIMD vector.
       interp: The interpolation method to use. See the struct [Interp](MMMWorld.md#struct-interp) for interpolation options.
       ADAA_dist: Whether to apply ADAA distortion to the feedback signal instead of standard tanh.
-      ov_samp: The [oversampling](Oversampling.md) index for ADAA distortion. 0 = no oversampling, 1 = 2x, 2 = 4x, 3 = 8x, 4 = 16x.
+      ov_samp: The [oversampling](MMMWorld.md#struct-timesoversampling) for ADAA distortion.
     """
 
     var world: World

--- a/mmm_audio/Distortion.mojo
+++ b/mmm_audio/Distortion.mojo
@@ -64,7 +64,7 @@ struct Latch[num_chans: Int = 1](Copyable, Movable):
 # [TODO] implement 2nd order ADAA versions of hard clip, soft clip, tanh
 # [TODO] implement a parameter in the .next functions to choose between none, and 1st and 2nd order ADAA
 
-struct SoftClipAD[num_chans: Int = 1, os_index: Int = 0, degree: Int = 3](Copyable, Movable):
+struct SoftClipAD[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversampling.none, degree: Int = 3](Copyable, Movable):
     """
     Anti-Derivative Anti-aliasing soft-clipping function.
     
@@ -72,13 +72,12 @@ struct SoftClipAD[num_chans: Int = 1, os_index: Int = 0, degree: Int = 3](Copyab
     
     Parameters:
         num_chans: The number of channels for SIMD operations.
-        os_index: The oversampling index (0 = no oversampling, 1 = 2x, 2 = 4x, 3 = 8x, 4 = 16x).
+        ov_samp: The oversampling index (0 = no oversampling, 1 = 2x, 2 = 4x, 3 = 8x, 4 = 16x).
         degree: The degree of the soft clipping polynomial (must be odd).
     """
-    comptime times_oversampling = 2 ** Self.os_index    
     var x1: MFloat[Self.num_chans]
-    var oversampling: Oversampling[Self.num_chans, Self.times_oversampling]
-    var upsampler: Upsampler[Self.num_chans, Self.times_oversampling]
+    var oversampling: Oversampling[Self.num_chans, Self.ov_samp]
+    var upsampler: Upsampler[Self.num_chans, Self.ov_samp]
     var D: Float64
     var norm_factor: Float64
     var inv_norm_factor: Float64
@@ -87,10 +86,10 @@ struct SoftClipAD[num_chans: Int = 1, os_index: Int = 0, degree: Int = 3](Copyab
 
     def __init__(out self, world: World):
         self.x1 = MFloat[Self.num_chans](0.0)
-        if Self.os_index > 1:
-            print("SoftClipAD: os_index greater than 1 not supported yet. It will not sound good.")
-        self.oversampling = Oversampling[Self.num_chans, Self.times_oversampling](world)
-        self.upsampler = Upsampler[Self.num_chans, 2 ** Self.os_index](world)
+        if Self.ov_samp.times > 2:
+            print("SoftClipAD: ov_samp greater than x2 not supported yet. It will not sound good.")
+        self.oversampling = Oversampling[Self.num_chans, self.ov_samp](world)
+        self.upsampler = Upsampler[Self.num_chans, self.ov_samp](world)
         self.D = Float64(Self.degree // 2 * 2 + 1)  # ensure degree is odd
         self.norm_factor = (self.D - 1) / self.D
         self.inv_norm_factor = 1.0 / self.norm_factor
@@ -143,7 +142,7 @@ struct SoftClipAD[num_chans: Int = 1, os_index: Int = 0, degree: Int = 3](Copyab
     def next(mut self, x: MFloat[Self.num_chans]) -> MFloat[Self.num_chans]:
         """First-order anti-aliased `hard_clip`.
 
-        Computes the first-order anti-aliased `hard_clip` of `x`. If the os_index is greater than 0, oversampling is applied to the processing.
+        Computes the first-order anti-aliased `hard_clip` of `x`. If the ov_samp is greater than 0, oversampling is applied to the processing.
 
         Args:
             x: The input sample.
@@ -151,10 +150,10 @@ struct SoftClipAD[num_chans: Int = 1, os_index: Int = 0, degree: Int = 3](Copyab
         Returns:
             The anti-aliased `soft_clip` of `x`.
         """
-        comptime if Self.os_index == 0:
+        comptime if Self.ov_samp == TimesOversampling.none:
             return self._next1(x)
         else:
-            comptime for i in range(self.times_oversampling):
+            comptime for i in range(Self.ov_samp.times):
                 # upsample the input
                 x2 = self.upsampler.next(x, i)
                 y = self._next1(x2)
@@ -169,7 +168,7 @@ def soft_clip[num_chans: Int](x: MFloat[num_chans], min_val: MFloat[num_chans] =
     var clipped = normalized / (1.0 + abs(normalized))
     return center + clipped * range
 
-struct HardClipAD[num_chans: Int = 1, os_index: Int = 0](Copyable, Movable):
+struct HardClipAD[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversampling.none](Copyable, Movable):
     """
     Anti-Derivative Anti-aliasing hard-clipping function.
     
@@ -177,12 +176,12 @@ struct HardClipAD[num_chans: Int = 1, os_index: Int = 0](Copyable, Movable):
     
     Parameters:
         num_chans: The number of channels for SIMD operations.
-        os_index: The oversampling index (0 = no oversampling, 1 = 2x, 2 = 4x, 3 = 8x, 4 = 16x).
+        ov_samp: The oversampling index (0 = no oversampling, 1 = 2x, 2 = 4x, 3 = 8x, 4 = 16x).
     """
     var x1: MFloat[Self.num_chans]
     var x2: MFloat[Self.num_chans]
-    var oversampling: Oversampling[Self.num_chans, 2 ** Self.os_index]
-    var upsampler: Upsampler[Self.num_chans, 2 ** Self.os_index]
+    var oversampling: Oversampling[Self.num_chans, Self.ov_samp]
+    var upsampler: Upsampler[Self.num_chans, Self.ov_samp]
     comptime TOL = 1.0e-5
 
     def __init__(out self, world: World):
@@ -193,8 +192,8 @@ struct HardClipAD[num_chans: Int = 1, os_index: Int = 0](Copyable, Movable):
         """
         self.x1 = MFloat[Self.num_chans](0.0)
         self.x2 = MFloat[Self.num_chans](0.0)
-        self.oversampling = Oversampling[Self.num_chans, 2 ** Self.os_index](world)
-        self.upsampler = Upsampler[Self.num_chans, 2 ** Self.os_index](world)
+        self.oversampling = Oversampling[Self.num_chans, Self.ov_samp](world)
+        self.upsampler = Upsampler[Self.num_chans, Self.ov_samp](world)
 
     @doc_hidden
     @always_inline
@@ -250,7 +249,7 @@ struct HardClipAD[num_chans: Int = 1, os_index: Int = 0](Copyable, Movable):
     def next(mut self, x: MFloat[Self.num_chans]) -> MFloat[Self.num_chans]:
         """First-order anti-aliased `hard_clip`.
 
-        Computes the first-order anti-aliased `hard_clip` of `x`. If the os_index is greater than 0, oversampling is applied to the processing.
+        Computes the first-order anti-aliased `hard_clip` of `x`. If the ov_samp is greater than 0, oversampling is applied to the processing.
 
         Args:
             x: The input sample.
@@ -258,31 +257,30 @@ struct HardClipAD[num_chans: Int = 1, os_index: Int = 0](Copyable, Movable):
         Returns:
             The anti-aliased `hard_clip` of `x`.
         """
-        comptime if Self.os_index == 0:
+        comptime if Self.ov_samp == TimesOversampling.none:
             return self._next1(x)
         else:
-            comptime times_oversampling = 2 ** Self.os_index
-            comptime for i in range(times_oversampling):
+            comptime for i in range(Self.ov_samp.times):
                 # upsample the input
                 x2 = self.upsampler.next(x, i)
                 y = self._next1(x2)
                 self.oversampling.add_sample(y)
             return self.oversampling.get_sample()
     
-struct TanhAD[num_chans: Int = 1, os_index: Int = 0](Copyable, Movable):
+struct TanhAD[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversampling.none](Copyable, Movable):
     """Anti-Derivative Anti-aliasing first order tanh function.
     
     This struct provides a first order anti-aliased version of the `tanh` function using the Anti-Derivative Anti-aliasing (ADAA) method with optional Oversampling. See [Practical Considerations for Antiderivative Anti-aliasing (Chowdhury)](https://ccrma.stanford.edu/~jatin/Notebooks/adaa.html) for more details on how this works.
 
     Parameters:
         num_chans: The number of channels for SIMD operations.
-        os_index: The oversampling index (0 = no oversampling, 1 = 2x, 2 = 4x, etc.).
+        ov_samp: The oversampling index (0 = no oversampling, 1 = 2x, 2 = 4x, etc.).
     """
 
     var x1: MFloat[Self.num_chans]
     comptime TOL = 1.0e-5
-    var oversampling: Oversampling[Self.num_chans, 2 ** Self.os_index]
-    var upsampler: Upsampler[Self.num_chans, 2 ** Self.os_index]
+    var oversampling: Oversampling[Self.num_chans, Self.ov_samp]
+    var upsampler: Upsampler[Self.num_chans, Self.ov_samp]
 
     def __init__(out self, world: World):
         """Initialize the TanhAD.
@@ -291,8 +289,8 @@ struct TanhAD[num_chans: Int = 1, os_index: Int = 0](Copyable, Movable):
             world: A pointer to the MMMWorld.
         """
         self.x1 = MFloat[Self.num_chans](0.0)
-        self.oversampling = Oversampling[Self.num_chans, 2 ** Self.os_index](world)
-        self.upsampler = Upsampler[Self.num_chans, 2 ** Self.os_index](world)
+        self.oversampling = Oversampling[Self.num_chans, Self.ov_samp](world)
+        self.upsampler = Upsampler[Self.num_chans, Self.ov_samp](world)
 
     @doc_hidden
     def _next_norm(mut self, x: MFloat[Self.num_chans]) -> MFloat[Self.num_chans]:
@@ -324,7 +322,7 @@ struct TanhAD[num_chans: Int = 1, os_index: Int = 0](Copyable, Movable):
     def next(mut self, x: MFloat[Self.num_chans]) -> MFloat[Self.num_chans]:
         """First-order anti-aliased `hard_clip`.
 
-        Computes the first-order anti-aliased `hard_clip` of `x` using the ADAA method. If the os_index is greater than 0, oversampling is applied to the processing.
+        Computes the first-order anti-aliased `hard_clip` of `x` using the ADAA method. If the ov_samp is greater than 0, oversampling is applied to the processing.
 
         Args:
             x: The input sample.
@@ -332,11 +330,10 @@ struct TanhAD[num_chans: Int = 1, os_index: Int = 0](Copyable, Movable):
         Returns:
             The anti-aliased `hard_clip` of `x`.
         """
-        comptime if Self.os_index == 0:
+        comptime if Self.ov_samp == TimesOversampling.none:
             return self._next1(x)
         else:
-            comptime times_oversampling = 2 ** Self.os_index
-            comptime for i in range(times_oversampling):
+            comptime for i in range(Self.ov_samp.times):
                 # upsample the input
                 x2 = self.upsampler.next(x, i)
                 y = self._next1(x2)
@@ -419,14 +416,14 @@ struct BuchlaCell[num_chans: Int = 1](Copyable, Movable):
     #                 - self.Bpp * sgn)
     #     return 0.0
 
-struct BuchlaWavefolder[num_chans: Int = 1, os_index: Int = 1](Copyable, Movable):
+struct BuchlaWavefolder[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversampling.x2](Copyable, Movable):
     """Buchla 259 style Wavefolder.
     
     Buchla 259 style wavefolder implementation with Anti-Derivative Anti-aliasing (ADAA) and Oversampling. Derived from Virual Analog Buchla 259e Wavefolderby Esqueda, etc. The ADAA technique is based on [Practical Considerations for Antiderivative Anti-aliasing (Chowdhury)](https://ccrma.stanford.edu/~jatin/Notebooks/adaa.html).
     
     Parameters:
         num_chans: The number of channels for SIMD operations.
-        os_index: The oversampling index (0 = no oversampling, 1 = 2x, 2 = 4x, etc.).
+        ov_samp: The oversampling index (0 = no oversampling, 1 = 2x, 2 = 4x, etc.).
     """
     
     comptime x_mix: Float64 = 5.0
@@ -434,8 +431,8 @@ struct BuchlaWavefolder[num_chans: Int = 1, os_index: Int = 1](Copyable, Movable
     comptime TOL: Float64 = 1.0e-5
     var x1: MFloat[Self.num_chans]
     var world: World
-    var oversampling: Oversampling[Self.num_chans, 2 ** Self.os_index]
-    var upsampler: Upsampler[Self.num_chans, 2 ** Self.os_index]
+    var oversampling: Oversampling[Self.num_chans, Self.ov_samp]
+    var upsampler: Upsampler[Self.num_chans, Self.ov_samp]
 
     def __init__(out self, world: World):
         """Initialize the BuchlaWavefolder.
@@ -452,8 +449,8 @@ struct BuchlaWavefolder[num_chans: Int = 1, os_index: Int = 1](Copyable, Movable
         self.cells.append(BuchlaCell[Self.num_chans](0.2829, 1.5446, 5.46, -21.428))
         self.cells.append(BuchlaCell[Self.num_chans](0.5743, 1.0338, 1.8, 17.647))
         self.cells.append(BuchlaCell[Self.num_chans](0.2673, 1.0907, 4.08, 36.363))
-        self.oversampling = Oversampling[Self.num_chans, 2 ** Self.os_index](world)
-        self.upsampler = Upsampler[Self.num_chans, 2 ** Self.os_index](world)
+        self.oversampling = Oversampling[Self.num_chans, Self.ov_samp](world)
+        self.upsampler = Upsampler[Self.num_chans, Self.ov_samp](world)
 
     @doc_hidden
     def _next_norm(self, x: MFloat[Self.num_chans], amp: Float64) -> MFloat[Self.num_chans]:
@@ -504,7 +501,7 @@ struct BuchlaWavefolder[num_chans: Int = 1, os_index: Int = 1](Copyable, Movable
     def next(mut self, x: MFloat[Self.num_chans], amp: Float64) -> MFloat[Self.num_chans]:
         """First-order anti-aliased BuchlaWavefolder.
 
-        Computes the first-order anti-aliased BuchlaWavefolder. If the os_index is greater than 0, oversampling is applied to the processing.
+        Computes the first-order anti-aliased BuchlaWavefolder. If the ov_samp is greater than 0, oversampling is applied to the processing.
 
         Args:
             x: The input sample.
@@ -513,11 +510,10 @@ struct BuchlaWavefolder[num_chans: Int = 1, os_index: Int = 1](Copyable, Movable
         Returns:
             The anti-aliased `hard_clip` of `x`.
         """
-        comptime if Self.os_index == 0:
+        comptime if Self.ov_samp == TimesOversampling.none:
             return self._next1(x, amp)
         else:
-            comptime times_oversampling = 2 ** Self.os_index
-            comptime for i in range(times_oversampling):
+            comptime for i in range(Self.ov_samp.times):
                 # upsample the input
                 x2 = self.upsampler.next(x, i)
                 y = self._next1(x2, amp)

--- a/mmm_audio/Distortion.mojo
+++ b/mmm_audio/Distortion.mojo
@@ -72,7 +72,7 @@ struct SoftClipAD[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversamp
     
     Parameters:
         num_chans: The number of channels for SIMD operations.
-        ov_samp: The oversampling index (0 = no oversampling, 1 = 2x, 2 = 4x, 3 = 8x, 4 = 16x).
+        ov_samp: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
         degree: The degree of the soft clipping polynomial (must be odd).
     """
     var x1: MFloat[Self.num_chans]
@@ -176,7 +176,7 @@ struct HardClipAD[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversamp
     
     Parameters:
         num_chans: The number of channels for SIMD operations.
-        ov_samp: The oversampling index (0 = no oversampling, 1 = 2x, 2 = 4x, 3 = 8x, 4 = 16x).
+        ov_samp: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
     """
     var x1: MFloat[Self.num_chans]
     var x2: MFloat[Self.num_chans]
@@ -274,7 +274,7 @@ struct TanhAD[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversampling
 
     Parameters:
         num_chans: The number of channels for SIMD operations.
-        ov_samp: The oversampling index (0 = no oversampling, 1 = 2x, 2 = 4x, etc.).
+        ov_samp: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
     """
 
     var x1: MFloat[Self.num_chans]
@@ -423,7 +423,7 @@ struct BuchlaWavefolder[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOv
     
     Parameters:
         num_chans: The number of channels for SIMD operations.
-        ov_samp: The oversampling index (0 = no oversampling, 1 = 2x, 2 = 4x, etc.).
+        ov_samp: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
     """
     
     comptime x_mix: Float64 = 5.0

--- a/mmm_audio/Filters.mojo
+++ b/mmm_audio/Filters.mojo
@@ -728,7 +728,7 @@ struct VAOnePole[num_chans: Int = 1](Movable, Copyable):
         """
         return input - self.lpf(input, freq)
 
-struct VAMoogLadder[num_chans: Int = 1, os_index: Int = 0](Movable, Copyable):
+struct VAMoogLadder[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversampling.none](Movable, Copyable):
     """Virtual Analog Moog Ladder Filter.
     
     Implementation based on the Virtual Analog design by Vadim Zavalishin in 
@@ -738,7 +738,7 @@ struct VAMoogLadder[num_chans: Int = 1, os_index: Int = 0](Movable, Copyable):
 
     Parameters:
         num_chans: Number of channels to process in parallel.
-        os_index: [oversampling](Oversampling.md) factor as a power of two (0 = no oversampling, 1 = 2x, 2 = 4x, etc).
+        ov_samp: [oversampling](Oversampling.md) factor as a power of two (0 = no oversampling, 1 = 2x, 2 = 4x, etc).
     """
     var nyquist: Float64
     var step_val: Float64
@@ -746,8 +746,8 @@ struct VAMoogLadder[num_chans: Int = 1, os_index: Int = 0](Movable, Copyable):
     var last_2: MFloat[Self.num_chans]
     var last_3: MFloat[Self.num_chans]
     var last_4: MFloat[Self.num_chans]
-    var oversampling: Oversampling[Self.num_chans, 2 ** Self.os_index]
-    var upsampler: Upsampler[Self.num_chans, 2 ** Self.os_index]
+    var oversampling: Oversampling[Self.num_chans, Self.ov_samp]
+    var upsampler: Upsampler[Self.num_chans, Self.ov_samp]
 
     def __init__(out self, world: World):
         """Initialize the VAMoogLadder filter.
@@ -755,14 +755,14 @@ struct VAMoogLadder[num_chans: Int = 1, os_index: Int = 0](Movable, Copyable):
         Args:
             world: Pointer to the MMMWorld.
         """
-        self.nyquist = world[].sample_rate * 0.5 * (2.0 ** Self.os_index)
+        self.nyquist = world[].sample_rate * 0.5 * Float64(Self.ov_samp.times)
         self.step_val = 1.0 / self.nyquist
         self.last_1 = MFloat[Self.num_chans](0.0)
         self.last_2 = MFloat[Self.num_chans](0.0)
         self.last_3 = MFloat[Self.num_chans](0.0)
         self.last_4 = MFloat[Self.num_chans](0.0)
-        self.oversampling = Oversampling[Self.num_chans, 2 ** Self.os_index](world)
-        self.upsampler = Upsampler[Self.num_chans, 2 ** Self.os_index](world)
+        self.oversampling = Oversampling[Self.num_chans, Self.ov_samp](world)
+        self.upsampler = Upsampler[Self.num_chans, Self.ov_samp](world)
 
     @doc_hidden
     @always_inline
@@ -782,8 +782,7 @@ struct VAMoogLadder[num_chans: Int = 1, os_index: Int = 0](Movable, Copyable):
         # k is the feedback coefficient of the entire circuit
         var k = 4.0 * res 
 
-        comptime os_factor = Float64(2 ** Self.os_index)
-        var compensation = 1.0 + k * os_factor * 0.25
+        var compensation = 1.0 + k * Float64(Self.ov_samp.times) * 0.25
         
         var omegaWarp = tan(pi * cf * self.step_val)
         var g = omegaWarp / (1.0 + omegaWarp)
@@ -841,17 +840,17 @@ struct VAMoogLadder[num_chans: Int = 1, os_index: Int = 0](Movable, Copyable):
             The next sample of the filtered output.
         """
         
-        comptime if Self.os_index == 0:
+        comptime if Self.ov_samp == TimesOversampling.none:
             return self.lp4(sig, freq, res)
         else:
-            comptime times_oversampling = 2 ** Self.os_index
 
-            comptime for i in range(times_oversampling):
+
+            comptime for i in range(Self.ov_samp.times):
                 # upsample the input
                 sig2 = self.upsampler.next(sig, i)
 
                 var lp4 = self.lp4(sig2, freq, res)
-                comptime if Self.os_index == 0:
+                comptime if Self.ov_samp == TimesOversampling.none:
                     return lp4
                 else:
                     self.oversampling.add_sample(lp4)

--- a/mmm_audio/Filters.mojo
+++ b/mmm_audio/Filters.mojo
@@ -738,7 +738,7 @@ struct VAMoogLadder[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversa
 
     Parameters:
         num_chans: Number of channels to process in parallel.
-        ov_samp: [oversampling](Oversampling.md) factor as a power of two (0 = no oversampling, 1 = 2x, 2 = 4x, etc).
+        ov_samp: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
     """
     var nyquist: Float64
     var step_val: Float64

--- a/mmm_audio/MMMWorld_Module.mojo
+++ b/mmm_audio/MMMWorld_Module.mojo
@@ -21,8 +21,6 @@ struct MMMWorld(Movable, Copyable):
     var sound_in: List[Float64]
 
     var screen_dims: List[Float64]  
-     
-    var os_multiplier: List[Float64]
 
     var mouse_x: Float64
     var mouse_y: Float64
@@ -70,10 +68,6 @@ struct MMMWorld(Movable, Copyable):
 
         self.osc_buffers = osc_buffers_ptr
         self.windows = windows_ptr
-
-        self.os_multiplier = List[Float64]()  # Initialize the list of multipliers
-        for i in range(5):  # Initialize multipliers for oversampling ratios
-            self.os_multiplier.append(1.0 / MFloat[1](2 ** i))  # Example multipliers, can be adjusted as needed
 
         self.mouse_x = 0.0
         self.mouse_y = 0.0
@@ -238,3 +232,26 @@ struct OscType(Equatable, ImplicitlyCopyable, Intable):
     @doc_hidden
     def __int__(self) -> Int:
         return self._value
+
+@fieldwise_init
+struct TimesOversampling(Equatable, ImplicitlyCopyable):
+    var times: Int
+
+    comptime none = TimesOversampling(1)
+    comptime x2 = TimesOversampling(2)
+    comptime x4 = TimesOversampling(4)
+    comptime x8 = TimesOversampling(8)
+    comptime x16 = TimesOversampling(16)
+
+    @doc_hidden
+    def __eq__(self, other: Self) -> Bool:
+        return self.times == other.times
+
+    @doc_hidden
+    def __ne__(self, other: Self) -> Bool:
+        return not (self == other)
+
+    @staticmethod
+    def get_freq_mul(world: World, ov_samp: TimesOversampling) -> Float64:
+        """Get the frequency multiplier for a given oversampling setting."""
+        return (1.0 /  world[].sample_rate) / Float64(ov_samp.times)

--- a/mmm_audio/Noise.mojo
+++ b/mmm_audio/Noise.mojo
@@ -222,13 +222,13 @@ struct LFSRNoise[num_chans: Int = 1](Copyable, Movable):
         self.mask                 = MInt[Self.num_chans](0)
         self.rising_bool_detector = RisingBoolDetector[Self.num_chans]()
 
-    def set_looped_times_oversampling(mut self, times_oversampling: Int):
+    def set_oversampling(mut self, times_oversampling: TimesOversampling):
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
             times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
         """
-        self.freq_mul = 1.0 / (self.world[].sample_rate * Float64(times_oversampling))
+        self.freq_mul = TimesOversampling.get_freq_mul(self.world, times_oversampling)
 
     @doc_hidden
     @always_inline

--- a/mmm_audio/Noise.mojo
+++ b/mmm_audio/Noise.mojo
@@ -226,7 +226,7 @@ struct LFSRNoise[num_chans: Int = 1](Copyable, Movable):
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
-            times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
+            times_oversampling: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
         """
         self.freq_mul = TimesOversampling.get_freq_mul(self.world, times_oversampling)
 

--- a/mmm_audio/Oscillators.mojo
+++ b/mmm_audio/Oscillators.mojo
@@ -1,7 +1,7 @@
 from std.math import sin, floor
 from mmm_audio import *
 
-struct Phasor[num_chans: Int = 1, os_index: Int = 0](Movable, Copyable):
+struct Phasor[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversampling.none](Movable, Copyable):
     """Phasor Oscillator.
 
     An oscillator that generates a ramp waveform from 0.0 to 1.0. The phasor is the root of all oscillators in MMMAudio.
@@ -12,7 +12,7 @@ struct Phasor[num_chans: Int = 1, os_index: Int = 0](Movable, Copyable):
 
     Parameters:
         num_chans: Number of channels.
-        os_index: Oversampling index (0 = no oversampling, 1 = 2x, up to 4 = 16x). Phasor does not downsample its output, so oversampling is only useful when used as part of other oversampled oscillators.
+        ov_samp: Oversampling index (0 = no oversampling, 1 = 2x, up to 4 = 16x). Phasor does not downsample its output, so oversampling is only useful when used as part of other oversampled oscillators.
     """
     var phase: MFloat[Self.num_chans]
     var freq_mul: Float64
@@ -28,7 +28,7 @@ struct Phasor[num_chans: Int = 1, os_index: Int = 0](Movable, Copyable):
         """
         self.world = world
         self.phase = MFloat[Self.num_chans](0.0)
-        self.freq_mul = self.world[].os_multiplier[Self.os_index] / self.world[].sample_rate
+        self.freq_mul = 1.0 / (Float64(Self.ov_samp.times) * self.world[].sample_rate)
         self.rising_bool_detector = RisingBoolDetector[Self.num_chans]()
         self.rising_bool_detector_impulse = RisingBoolDetector[Self.num_chans]()
 
@@ -102,16 +102,16 @@ struct Phasor[num_chans: Int = 1, os_index: Int = 0](Movable, Copyable):
 
         return self.next_bool(freq, phase_offset, trig).cast[DType.float64]()
 
-    def set_looped_times_oversampling(mut self, times_oversampling: Int):
+    def set_oversampling(mut self, times_oversampling: TimesOversampling):
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
             times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
         """
-        self.freq_mul = (1.0 / self.world[].sample_rate) / Float64(times_oversampling)
+        self.freq_mul = TimesOversampling.get_freq_mul(self.world, times_oversampling)
 
 
-struct Impulse[num_chans: Int = 1, os_index: Int = 0](Movable, Copyable):
+struct Impulse[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversampling.none](Movable, Copyable):
     """Impulse Oscillator.
 
     An oscillator that outputs a 1.0 or True for one sample when the phase wraps around from 1.0 to 0.0.
@@ -120,9 +120,9 @@ struct Impulse[num_chans: Int = 1, os_index: Int = 0](Movable, Copyable):
 
     Parameters:
         num_chans: Number of channels (default is 1).
-        os_index: Oversampling index (0 = no oversampling, 1 = 2x, etc.; default is 0).
+        ov_samp: Oversampling index (0 = no oversampling, 1 = 2x, etc.; default is 0).
     """
-    var phasor: Phasor[Self.num_chans, Self.os_index]  # Instance of the Phasor
+    var phasor: Phasor[Self.num_chans, Self.ov_samp]  # Instance of the Phasor
 
     def __init__(out self, world: World):
         """
@@ -130,15 +130,15 @@ struct Impulse[num_chans: Int = 1, os_index: Int = 0](Movable, Copyable):
         Args:
             world: Pointer to the MMMWorld instance.
         """
-        self.phasor = Phasor[self.num_chans, Self.os_index](world)
+        self.phasor = Phasor[self.num_chans, Self.ov_samp](world)
 
-    def set_looped_times_oversampling(mut self, times_oversampling: Int):
+    def set_oversampling(mut self, times_oversampling: TimesOversampling):
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
             times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
         """
-        self.phasor.set_looped_times_oversampling(times_oversampling)
+        self.phasor.set_oversampling(times_oversampling)
 
     @always_inline
     def next_bool(mut self, freq: MFloat[self.num_chans] = 100.0, phase_offset: MFloat[self.num_chans] = 0.0, trig: MBool[self.num_chans] = MBool[self.num_chans](fill=True)) -> MBool[self.num_chans]:
@@ -170,7 +170,7 @@ struct Impulse[num_chans: Int = 1, os_index: Int = 0](Movable, Copyable):
 
         return self.phasor.next_impulse(freq, phase_offset, trig)
 
-struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, os_index: Int = 0](Movable, Copyable):
+struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, ov_samp: TimesOversampling = TimesOversampling.none](Movable, Copyable):
     """Wavetable Oscillator Core.
 
     A wavetable oscillator capable of all standard waveforms and also able to load custom wavetables. Capable of linear, cubic, quadratic, lagrange, or sinc interpolation. Also capable of [Oversampling](Oversampling.md).
@@ -182,12 +182,12 @@ struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, os_index: Int = 0
     Parameters:
         num_chans: Number of channels (default is 1).
         interp: Interpolation method. See [Interp](MMMWorld.md/#struct-interp) struct for options (default is Interp.linear).
-        os_index: [Oversampling](Oversampling.md) index (0 = no oversampling, 1 = 2x, 2 = 4x, etc.; default is 0).
+        ov_samp: [Oversampling](Oversampling.md) index (0 = no oversampling, 1 = 2x, 2 = 4x, etc.; default is 0).
     """
 
-    var phasor: Phasor[Self.num_chans, Self.os_index]
+    var phasor: Phasor[Self.num_chans, Self.ov_samp]
     var world: World 
-    var oversampling: Oversampling[Self.num_chans, 2**Self.os_index]
+    var oversampling: Oversampling[Self.num_chans, Self.ov_samp]
     var last_phase: MFloat[Self.num_chans]
 
     def __init__(out self, world: World):
@@ -197,17 +197,17 @@ struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, os_index: Int = 0
             world: Pointer to the MMMWorld instance.
         """
         self.world = world
-        self.phasor = Phasor[self.num_chans, Self.os_index](self.world)
-        self.oversampling = Oversampling[self.num_chans, 2**Self.os_index](self.world)
+        self.phasor = Phasor[self.num_chans, Self.ov_samp](self.world)
+        self.oversampling = Oversampling[self.num_chans, Self.ov_samp](self.world)
         self.last_phase = MFloat[self.num_chans](0.0)
 
-    def set_looped_times_oversampling(mut self, times_oversampling: Int):
+    def set_oversampling(mut self, times_oversampling: TimesOversampling):
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
             times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
         """
-        self.phasor.set_looped_times_oversampling(times_oversampling)
+        self.phasor.set_oversampling(times_oversampling)
 
     @always_inline
     def next[osc_type: OscType = OscType.sine](
@@ -236,7 +236,7 @@ struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, os_index: Int = 0
 
         comptime osc_type_int = Int(osc_type)
 
-        comptime if Self.os_index == 0:
+        comptime if Self.ov_samp == TimesOversampling.none:
             
             # last_phase = self.phasor.phase  # Store the last phase for sinc interpolation
             phase = self.phasor.next(freq, phase_offset, trig_mask)
@@ -255,7 +255,7 @@ struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, os_index: Int = 0
             self.last_phase = phase
             return out
         else:
-            comptime for i in range(2**Self.os_index):
+            comptime for i in range(Self.ov_samp.times):
                 
                 # last_phase = self.phasor.phase  # Store the last phase for sinc interpolation
                 phase = self.phasor.next(freq, phase_offset, trig_mask)
@@ -344,7 +344,7 @@ struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, os_index: Int = 0
         osc_frac_interp = scaled_osc_frac - floor(scaled_osc_frac) 
         var out_sample = MFloat[self.num_chans](0.0) 
 
-        comptime if Self.os_index == 0:
+        comptime if Self.ov_samp == TimesOversampling.none:
             var phase = self.phasor.next(freq, phase_offset, trig_mask)
             comptime for chan in range(self.num_chans):
                 sample = self.next_all_basic_waveforms(freq[chan], phase[chan], self.last_phase[chan], trig)
@@ -352,7 +352,7 @@ struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, os_index: Int = 0
             self.last_phase = phase
             return out_sample
         else:
-            comptime for i in range(2**Self.os_index):
+            comptime for i in range(Self.ov_samp.times):
                 var phase = self.phasor.next(freq, phase_offset, trig_mask)
                 comptime for chan in range(self.num_chans):
                     sample = self.next_all_basic_waveforms(freq[chan], phase[chan], self.last_phase[chan], trig)
@@ -395,7 +395,7 @@ struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, os_index: Int = 0
         var sample0 = MFloat[self.num_chans](0.0)
         var sample1 = MFloat[self.num_chans](0.0)
 
-        comptime if Self.os_index == 0:
+        comptime if Self.ov_samp == TimesOversampling.none:
             # var last_phase = self.phasor.phase
             var phase = self.phasor.next(freq, phase_offset, trig_mask)
             comptime for out_chan in range(self.num_chans):
@@ -422,7 +422,7 @@ struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, os_index: Int = 0
             self.last_phase = phase
             return linear_interp(sample0, sample1, scaled_osc_frac)
         else:
-            comptime times_os_int = 2**Self.os_index
+            comptime times_os_int = Self.ov_samp.times
             comptime for i in range(times_os_int):
                 # var last_phase = self.phasor.phase
                 var phase = self.phasor.next(freq, phase_offset, trig_mask)
@@ -482,7 +482,7 @@ struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, os_index: Int = 0
 
         scaled_osc_frac = chan0_fl - floor(chan0_fl)
 
-        comptime if Self.os_index == 0:
+        comptime if Self.ov_samp == TimesOversampling.none:
             # var last_phase = self.phasor.phase
             var phase = self.phasor.next(freq, phase_offset, trig_mask)
             out_sample = MFloat[self.num_chans](0.0)
@@ -502,7 +502,7 @@ struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, os_index: Int = 0
             self.last_phase = phase
             return out_sample
         else:
-            comptime times_os_int = 2**Self.os_index
+            comptime times_os_int = Self.ov_samp.times
             comptime for i in range(times_os_int):
                 # var last_phase = self.phasor.phase
                 var phase = self.phasor.next(freq, phase_offset, trig_mask)
@@ -597,13 +597,13 @@ struct LFOsc[num_chans: Int = 1] (Movable, Copyable):
             phase = self.phasor.next(freq, phase_offset, trig_mask)
             return sin(phase * two_pi)
 
-    def set_looped_times_oversampling(mut self, times_oversampling: Int):
+    def set_oversampling(mut self, times_oversampling: TimesOversampling):
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
             times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
         """
-        self.phasor.set_looped_times_oversampling(times_oversampling)
+        self.phasor.set_oversampling(times_oversampling)
 
 struct Dust[num_chans: Int = 1] (Movable, Copyable):
     """A dust noise oscillator that generates random impulses at random intervals.
@@ -668,13 +668,13 @@ struct Dust[num_chans: Int = 1] (Movable, Copyable):
     def set_phase(mut self, phase: MFloat[self.num_chans]):
         self.impulse.phase = phase
 
-    def set_looped_times_oversampling(mut self, times_oversampling: Int):
+    def set_oversampling(mut self, times_oversampling: TimesOversampling):
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
             times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
         """
-        self.impulse.set_looped_times_oversampling(times_oversampling)
+        self.impulse.set_oversampling(times_oversampling)
 
 
 struct TTrig(Movable, Copyable):
@@ -798,13 +798,13 @@ struct LFNoise[num_chans: Int = 1, interp: Interp = Interp.cubic](Movable, Copya
             # Cubic interpolation
             return cubic_interp(p0, p1, p2, p3, self.impulse.phase)
 
-    def set_looped_times_oversampling(mut self, times_oversampling: Int):
+    def set_oversampling(mut self, times_oversampling: TimesOversampling):
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
             times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
         """
-        self.impulse.set_looped_times_oversampling(times_oversampling)
+        self.impulse.set_oversampling(times_oversampling)
 
 struct Sweep[num_chans: Int = 1](Movable, Copyable):
     """A phase accumulator.
@@ -851,13 +851,13 @@ struct Sweep[num_chans: Int = 1](Movable, Copyable):
 
         return self.phase
 
-    def set_looped_times_oversampling(mut self, times_oversampling: Int):
+    def set_oversampling(mut self, times_oversampling: TimesOversampling):
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
             times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
         """
-        self.freq_mul = 1.0 / (self.world[].sample_rate * Float64(times_oversampling))
+        self.freq_mul = TimesOversampling.get_freq_mul(self.world, times_oversampling)
 
 struct Line[num_chans: Int = 1, linexpcurve: Int = 0](Movable, Copyable):
     """
@@ -913,13 +913,13 @@ struct Line[num_chans: Int = 1, linexpcurve: Int = 0](Movable, Copyable):
         else:
             return linlin(self.phase, 0.0, 1.0, start, end)
 
-    def set_looped_times_oversampling(mut self, times_oversampling: Int):
+    def set_oversampling(mut self, times_oversampling: TimesOversampling):
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
             times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
         """
-        self.freq_mul = 1.0 / (self.world[].sample_rate * Float64(times_oversampling))
+        self.freq_mul = TimesOversampling.get_freq_mul(self.world, times_oversampling)
 
 comptime OscBuffersSize: Int = 16384  # 2^14
 comptime OscBuffersMask: Int = 16383  # 2^14 - 1

--- a/mmm_audio/Oscillators.mojo
+++ b/mmm_audio/Oscillators.mojo
@@ -12,7 +12,7 @@ struct Phasor[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversampling
 
     Parameters:
         num_chans: Number of channels.
-        ov_samp: Oversampling index (0 = no oversampling, 1 = 2x, up to 4 = 16x). Phasor does not downsample its output, so oversampling is only useful when used as part of other oversampled oscillators.
+        ov_samp: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling. Phasor does not downsample its output, so oversampling is only useful when used as part of other oversampled oscillators.
     """
     var phase: MFloat[Self.num_chans]
     var freq_mul: Float64
@@ -106,7 +106,7 @@ struct Phasor[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversampling
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
-            times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
+            times_oversampling: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
         """
         self.freq_mul = TimesOversampling.get_freq_mul(self.world, times_oversampling)
 
@@ -120,7 +120,7 @@ struct Impulse[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversamplin
 
     Parameters:
         num_chans: Number of channels (default is 1).
-        ov_samp: Oversampling index (0 = no oversampling, 1 = 2x, etc.; default is 0).
+        ov_samp: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
     """
     var phasor: Phasor[Self.num_chans, Self.ov_samp]  # Instance of the Phasor
 
@@ -136,7 +136,7 @@ struct Impulse[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversamplin
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
-            times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
+            times_oversampling: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
         """
         self.phasor.set_oversampling(times_oversampling)
 
@@ -182,7 +182,7 @@ struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, ov_samp: TimesOve
     Parameters:
         num_chans: Number of channels (default is 1).
         interp: Interpolation method. See [Interp](MMMWorld.md/#struct-interp) struct for options (default is Interp.linear).
-        ov_samp: [Oversampling](Oversampling.md) index (0 = no oversampling, 1 = 2x, 2 = 4x, etc.; default is 0).
+        ov_samp: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
     """
 
     var phasor: Phasor[Self.num_chans, Self.ov_samp]
@@ -205,7 +205,7 @@ struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, ov_samp: TimesOve
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
-            times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
+            times_oversampling: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
         """
         self.phasor.set_oversampling(times_oversampling)
 
@@ -601,7 +601,7 @@ struct LFOsc[num_chans: Int = 1] (Movable, Copyable):
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
-            times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
+            times_oversampling: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
         """
         self.phasor.set_oversampling(times_oversampling)
 
@@ -672,7 +672,7 @@ struct Dust[num_chans: Int = 1] (Movable, Copyable):
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
-            times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
+            times_oversampling: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
         """
         self.impulse.set_oversampling(times_oversampling)
 
@@ -802,7 +802,7 @@ struct LFNoise[num_chans: Int = 1, interp: Interp = Interp.cubic](Movable, Copya
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
-            times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
+            times_oversampling: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
         """
         self.impulse.set_oversampling(times_oversampling)
 
@@ -855,7 +855,7 @@ struct Sweep[num_chans: Int = 1](Movable, Copyable):
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
-            times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
+            times_oversampling: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
         """
         self.freq_mul = TimesOversampling.get_freq_mul(self.world, times_oversampling)
 
@@ -917,7 +917,7 @@ struct Line[num_chans: Int = 1, linexpcurve: Int = 0](Movable, Copyable):
         """Sets times oversampling for the oscillator when it is used in an Oversampling loop. This is not for when using the oscillator with the built-in oversampling, but rather for when the oscillator is used as part of a custom oversampling implementation.
 
         Args:
-            times_oversampling: The new oversampling multiplier (1 for no oversampling, 2 for 2x, 4 for 4x, etc.).
+            times_oversampling: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
         """
         self.freq_mul = TimesOversampling.get_freq_mul(self.world, times_oversampling)
 

--- a/mmm_audio/Oversampling_Module.mojo
+++ b/mmm_audio/Oversampling_Module.mojo
@@ -1,14 +1,14 @@
 from mmm_audio import *
 
-struct Oversampling[num_chans: Int = 1, times_oversampling: Int = 0](Movable, Copyable):
+struct Oversampling[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversampling.none](Movable, Copyable):
     """A struct that collects ` times_oversampling` samples and then downsamples them using a low-pass filter. Add a sample for each oversampling iteration with `add_sample()`, then get the downsampled output with `get_sample()`.
 
     Parameters:
         num_chans: Number of channels for the oversampling buffer.
-        times_oversampling: The oversampling factor (e.g., 2 for 2x oversampling).
+        ov_samp: The oversampling factor (e.g., 2 for 2x oversampling).
     """
 
-    var buffer: InlineArray[MFloat[Self.num_chans], Self.times_oversampling]  # Buffer for oversampled values
+    var buffer: InlineArray[MFloat[Self.num_chans], Self.ov_samp.times]  # Buffer for oversampled values
     var counter: Int
     var lpf: OS_LPF4[Self.num_chans]
 
@@ -19,9 +19,9 @@ struct Oversampling[num_chans: Int = 1, times_oversampling: Int = 0](Movable, Co
             world: Pointer to the MMMWorld instance.
         """
         self.lpf = OS_LPF4[self.num_chans](world)
-        self.buffer = InlineArray[MFloat[Self.num_chans], Self.times_oversampling](fill=MFloat[Self.num_chans](0.0))
+        self.buffer = InlineArray[MFloat[Self.num_chans], Self.ov_samp.times](fill=MFloat[Self.num_chans](0.0))
         self.counter = 0
-        self.lpf.set_sample_rate(world[].sample_rate * MFloat[1](Self.times_oversampling))
+        self.lpf.set_sample_rate(world[].sample_rate * MFloat[1](Self.ov_samp.times))
         
         self.lpf.set_cutoff(0.48 * world[].sample_rate)
 
@@ -40,19 +40,19 @@ struct Oversampling[num_chans: Int = 1, times_oversampling: Int = 0](Movable, Co
         """Get the next sample from a filled oversampling buffer."""
         out = MFloat[self.num_chans](0.0)
         if self.counter > 1:
-            for i in range(Self.times_oversampling):
+            for i in range(Self.ov_samp.times):
                 out = self.lpf.next(self.buffer[i]) # Lowpass filter each sample
         else:
             out = self.buffer[0]
         self.counter = 0
         return out
         
-struct Upsampler[num_chans: Int = 1, times_oversampling: Int = 1](Movable, Copyable):
+struct Upsampler[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversampling.x2](Movable, Copyable):
     """A struct that upsamples the input signal by the specified factor using a low-pass filter.
 
     Parameters:
         num_chans: Number of channels for the upsampler.
-        times_oversampling: The oversampling factor (e.g., 2 for 2x oversampling).
+        ov_samp: The oversampling factor (e.g., 2 for 2x oversampling).
     """
     var lpf: OS_LPF4[Self.num_chans]
 
@@ -63,7 +63,7 @@ struct Upsampler[num_chans: Int = 1, times_oversampling: Int = 1](Movable, Copya
             world: Pointer to the MMMWorld instance.
         """
         self.lpf = OS_LPF4[Self.num_chans](world)
-        self.lpf.set_sample_rate(world[].sample_rate * MFloat[1](Self.times_oversampling))
+        self.lpf.set_sample_rate(world[].sample_rate * MFloat[1](Self.ov_samp.times))
         self.lpf.set_cutoff(0.5 * world[].sample_rate)
 
     @always_inline
@@ -78,9 +78,9 @@ struct Upsampler[num_chans: Int = 1, times_oversampling: Int = 1](Movable, Copya
             The next sample of the upsampled output.
         """
         if i == 0:
-            return self.lpf.next(input) * MFloat[1](Self.times_oversampling)
+            return self.lpf.next(input) * MFloat[1](Self.ov_samp.times)
         else:
-            return self.lpf.next(MFloat[Self.num_chans](0.0)) * MFloat[1](Self.times_oversampling)
+            return self.lpf.next(MFloat[Self.num_chans](0.0)) * MFloat[1](Self.ov_samp.times)
 
 struct OS_LPF[num_chans: Int = 1](Movable, Copyable):
     """A simple 2nd-order low-pass filter for oversampling applications. Does not allow changing cutoff frequency on the fly to avoid that calculation each sample.

--- a/mmm_audio/Oversampling_Module.mojo
+++ b/mmm_audio/Oversampling_Module.mojo
@@ -5,7 +5,7 @@ struct Oversampling[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversa
 
     Parameters:
         num_chans: Number of channels for the oversampling buffer.
-        ov_samp: The oversampling factor (e.g., 2 for 2x oversampling).
+        ov_samp: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
     """
 
     var buffer: InlineArray[MFloat[Self.num_chans], Self.ov_samp.times]  # Buffer for oversampled values
@@ -52,7 +52,7 @@ struct Upsampler[num_chans: Int = 1, ov_samp: TimesOversampling = TimesOversampl
 
     Parameters:
         num_chans: Number of channels for the upsampler.
-        ov_samp: The oversampling factor (e.g., 2 for 2x oversampling).
+        ov_samp: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
     """
     var lpf: OS_LPF4[Self.num_chans]
 

--- a/mmm_audio/Synthesizers.mojo
+++ b/mmm_audio/Synthesizers.mojo
@@ -3,7 +3,7 @@ from mmm_audio import *
 struct PAF[
     num_chans: Int = 1,
     interp: Interp = Interp.linear,
-    os_index: Int = 0,
+    ov_samp: TimesOversampling = TimesOversampling.none,
     wrap_gaussian: Bool = False,
 ](Copyable, Movable):
     """Phase-Aligned Formant generator using a single phasor to synthesize multiple windows. From Miller Puckette's "Theory and Technique of Electronic Music," page 170.
@@ -11,7 +11,7 @@ struct PAF[
     Parameters:
         num_chans: Number of channels.
         interp: Interpolation method. See [Interp](MMMWorld.md/#struct-interp) struct for options.
-        os_index: [Oversampling](Oversampling.md) index (0 = no oversampling, 1 = 2x, 2 = 4x, etc.).
+        ov_samp: [Oversampling](Oversampling.md) index (0 = no oversampling, 1 = 2x, 2 = 4x, etc.).
         wrap_gaussian: Whether to wrap indices that go out of bounds in the gaussian window. Puckette's design only uses half of the table, but enabling wrap_gaussian uses the entire table, resulting in a wider pallette of timbres.
     """
 
@@ -29,7 +29,7 @@ struct PAF[
     var gaussian: Windows
     var cos1_last_phase: MFloat[Self.num_chans]
 
-    var oversampling: Oversampling[Self.num_chans, 2**Self.os_index]
+    var oversampling: Oversampling[Self.num_chans, Self.ov_samp]
 
     def __init__(out self, world: World):
         """
@@ -39,7 +39,7 @@ struct PAF[
         self.world = world
 
         self.phasor = Phasor[Self.num_chans](self.world)
-        self.phasor.freq_mul = self.world[].os_multiplier[Self.os_index] / self.world[].sample_rate
+        self.phasor.freq_mul = TimesOversampling.get_freq_mul(self.world,Self.ov_samp)
         
         self.cos1 = Osc[Self.num_chans, Self.interp](self.world)
         self.cos2 = Osc[Self.num_chans, Self.interp](self.world)
@@ -54,7 +54,7 @@ struct PAF[
         self.gaussian = Windows()
         self.cos1_last_phase = MFloat[self.num_chans](0.0)
 
-        self.oversampling = Oversampling[Self.num_chans, 2**Self.os_index](
+        self.oversampling = Oversampling[Self.num_chans, Self.ov_samp](
             self.world
         )
 
@@ -81,7 +81,7 @@ struct PAF[
         a = center_freq / fund
         b = wrap(a, 0.0, 1.0)
 
-        comptime for _ in range(2**Self.os_index):
+        comptime for _ in range(Self.ov_samp.times):
             phasor = self.phasor.next(fund)
 
             cos1_phase = phasor * (a - b)
@@ -113,11 +113,11 @@ struct PAF[
             self.cos1_last_phase = cos1_phase
 
             # add sample to oversampling buffer each iteration
-            if self.os_index != 0:
+            if Self.ov_samp != TimesOversampling.none:
                 self.oversampling.add_sample(out)
 
         # retrive sample from oversampling buffer only if oversampling is enabled
-        if self.os_index != 0:
+        if Self.ov_samp != TimesOversampling.none:
             return self.oversampling.get_sample()
         else:
             return out

--- a/mmm_audio/Synthesizers.mojo
+++ b/mmm_audio/Synthesizers.mojo
@@ -11,7 +11,7 @@ struct PAF[
     Parameters:
         num_chans: Number of channels.
         interp: Interpolation method. See [Interp](MMMWorld.md/#struct-interp) struct for options.
-        ov_samp: [Oversampling](Oversampling.md) index (0 = no oversampling, 1 = 2x, 2 = 4x, etc.).
+        ov_samp: An [oversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
         wrap_gaussian: Whether to wrap indices that go out of bounds in the gaussian window. Puckette's design only uses half of the table, but enabling wrap_gaussian uses the entire table, resulting in a wider pallette of timbres.
     """
 

--- a/workshop_templates/SubtractiveTemplate.mojo
+++ b/workshop_templates/SubtractiveTemplate.mojo
@@ -28,11 +28,11 @@ struct SubtractiveTemplate(Movable, Copyable):
     var m: Messenger
 
     # Oscillator stuff
-    var saw: Osc[num_chans=num_chans,interp=Interp.quad,os_index=oversample_index]
+    var saw: Osc[num_chans=num_chans,interp=Interp.quad,ov_samp=oversample_index]
     var freq: MFloat[1]
 
     # Filter stuff
-    var lpf: VAMoogLadder[num_chans=num_chans,os_index=oversample_index]
+    var lpf: VAMoogLadder[num_chans=num_chans,ov_samp=oversample_index]
     var ffreq: MFloat[1]
     var res: MFloat[1]
 
@@ -41,23 +41,23 @@ struct SubtractiveTemplate(Movable, Copyable):
     var lfo_freq: MFloat[1]
 
     # Wavefolder
-    # var wavefolder: BuchlaWavefolder[num_chans=num_chans,os_index=oversample_index]
+    # var wavefolder: BuchlaWavefolder[num_chans=num_chans,ov_samp=oversample_index]
     # var fold_amt: MFloat[1]
 
     def __init__(out self, world: World):
         self.world = world
         self.m = Messenger(self.world)
         
-        self.saw = Osc[num_chans=num_chans,interp=Interp.quad,os_index=oversample_index](self.world)
+        self.saw = Osc[num_chans=num_chans,interp=Interp.quad,ov_samp=oversample_index](self.world)
         self.freq = MFloat[1](440.0)
 
-        # self.wavefolder = BuchlaWavefolder[num_chans=num_chans,os_index=oversample_index](self.world)
+        # self.wavefolder = BuchlaWavefolder[num_chans=num_chans,ov_samp=oversample_index](self.world)
         # self.fold_amt = MFloat[1](0.5)
         
         self.lfo = Osc[](self.world)
         self.lfo_freq = MFloat[1](3)
 
-        self.lpf = VAMoogLadder[num_chans=num_chans,os_index=oversample_index](self.world)
+        self.lpf = VAMoogLadder[num_chans=num_chans,ov_samp=oversample_index](self.world)
         self.ffreq = MFloat[1](1000.0)
         self.res = MFloat[1](0.5)
         


### PR DESCRIPTION
All tests passing. Listened to a couple of the example / test files. Sounds good. There was a lot of manual editing in individual files, so I might have a fat finger error somewhere, but I think I did a good job. Plus with the testing and now the stonger-typed enum for this feature, the code base should be more sensitive (in a good way) to the kinds of user errors I might miss in testing.

It's nice that things like `os_index = 2` are no more because as I was doing these changes, I kept thinking that totally looks like x2 oversampling, but it's not! same with `os_index = 4` and `os_index = 1`.