### PR TITLE
World / Environment Refactor

### DIFF
--- a/examples/FM4.mojo
+++ b/examples/FM4.mojo
@@ -29,7 +29,7 @@ struct FM4(Movable, Copyable):
 
     def __init__(out self, world: World) :
         # create a subworld for the downsampling to live in
-        self.oversampled_world = create_subworld(world, Self.times_oversampling)
+        self.oversampled_world = world[].create_subworld(Self.times_oversampling)
 
         # the oversampler exists in the main world! don't give it the oversampled world!
         self.over = Downsampler[2, Self.times_oversampling](world)

--- a/examples/MoogPops.mojo
+++ b/examples/MoogPops.mojo
@@ -18,7 +18,7 @@ struct MoogPops(Movable, Copyable):
 
     def __init__(out self, world: World):
         self.world = world
-        oversampled_world = create_subworld(world, times_oversampling)
+        oversampled_world = self.world[].create_subworld(times_oversampling)
         self.dusts = Dust[how_many](oversampled_world)
         self.filts = VAMoogLadder[how_many](oversampled_world)
 

--- a/examples/tests/TestOscOversampling.mojo
+++ b/examples/tests/TestOscOversampling.mojo
@@ -29,7 +29,7 @@ struct TestOscOversampling(Movable, Copyable):
         self.lag = Lag(world, 0.1)
 
         self.downsampler = Downsampler[1,TimesOversampling.x16](world)
-        oversampled_world = create_subworld(world, TimesOversampling.x16)
+        oversampled_world = world[].create_subworld(TimesOversampling.x16)
         self.osc5 = Osc[1,Interp.linear](oversampled_world)
 
     def next(mut self) -> Float64:

--- a/mmm_audio/Buffer_Module.mojo
+++ b/mmm_audio/Buffer_Module.mojo
@@ -202,7 +202,7 @@ struct Buffer(Movable, Copyable):
         self.duration = self.num_frames_f64 / self.sample_rate
 
     def at_phase[interp: Interp = Interp.none, bWrap: Bool = True, mask: Int = 0](self, world: World, chan: Int, phase: Float64, prev_phase: Float64 = 0) -> MFloat[1]:
-        """Read a value from the Buffer at a given phase using sinc interpolation.
+        """Read a value from the Buffer at a given phase using interpolation.
 
         Parameters:
             interp: Interpolation method to use (from [Interp](MMMWorld.md#struct-interp) enum).
@@ -213,7 +213,7 @@ struct Buffer(Movable, Copyable):
             world: Pointer to the MMMWorld instance.
             chan: The channel to read from.
             phase: The phase to read at, where 0.0 is the beginning of the buffer and 1.0 is the end of the buffer.
-            prev_phase: The previous phase (used for calculating the sinc interpolation).
+            prev_phase: The previous phase (used if calculating sinc interpolation).
 
         Returns:
             The interpolated sample value at the given phase.
@@ -592,4 +592,4 @@ struct SpanInterpolator(Movable, Copyable):
         Returns:
             The sinc-interpolated sample value.
         """
-        return world[].sinc_interpolator.value()[].sinc_interp[num_chans,bWrap,mask](data, f_idx, prev_f_idx)
+        return world[].sinc_interpolator().sinc_interp[num_chans,bWrap,mask](data, f_idx, prev_f_idx)

--- a/mmm_audio/Envelopes.mojo
+++ b/mmm_audio/Envelopes.mojo
@@ -279,8 +279,7 @@ def win_read[window_type: WindowType = WindowType.sine, interp: Interp = Interp.
     Returns:
         The window value at the specified phase.
     """
-    temp = world[].windows.value()
-    val = temp[].at_phase[window_type=window_type, interp=interp](world, phase)
+    val = world[].windows().at_phase[window_type=window_type, interp=interp](world, phase)
     return val
 
 def buf_read[num_chans: Int, interp: Interp = Interp.linear, bWrap: Bool = True](world: World, env_buffer: SIMDBuffer[num_chans], phase: MFloat[1], prev_phase: MFloat[1] = 0.0) -> MFloat[num_chans]:

--- a/mmm_audio/MBufAnalysisBridge.mojo
+++ b/mmm_audio/MBufAnalysisBridge.mojo
@@ -180,10 +180,10 @@ struct MBufAnalysisBridge:
 
         w = alloc[MMMWorld](1) 
         # TODO: need to find a new way to pass the missing pointers
-        world_info = alloc[WorldInfo](1)
-        world_info.init_pointee_move(WorldInfo(64, 2, 2))
+        environment = alloc[Environment](1)
+        environment.init_pointee_move(Environment(64, 2, 2))
 
-        w.init_pointee_move(MMMWorld(analysis_params.buf.sample_rate, world_info))
+        w.init_pointee_move(MMMWorld(analysis_params.buf.sample_rate, environment))
 
         # run the analysis
         sf_onsets = SpectralFluxOnsets(w,window_size,hop_size,filter_size)

--- a/mmm_audio/MMMAudioBridge.mojo
+++ b/mmm_audio/MMMAudioBridge.mojo
@@ -42,18 +42,18 @@ def PyInit_GrainsBridge() abi("C") -> PythonObject:
 @fieldwise_init
 struct MMMAudioBridge(Movable, Writable):
     var world: World
-    var graph: Grains  # The audio graph instance
+    var graph: Grains
     var environment_ptr: UnsafePointer[mut=True, Environment, MutUntrackedOrigin]
 
-    # def(args: PythonObject, kwargs: PythonObject) raises -> MMMAudioBridge
     @staticmethod
     def py_init(out self: MMMAudioBridge, args: PythonObject, kwargs: PythonObject) raises:
 
-        var sample_rate = Float64(py=args[0])
-        var block_size: Int = Int(py=args[1])
+        args_dict = args[0]
 
-        var num_out_chans: Int = 2
-        var num_in_chans: Int = 2
+        sample_rate = Float64(py=args_dict["sample_rate"])
+        block_size = Int(py=args_dict["block_size"])
+        num_in_chans = Int(py=args_dict["num_in_chans"])
+        num_out_chans = Int(py=args_dict["num_out_chans"])
 
         self = Self(sample_rate, block_size, num_in_chans, num_out_chans)
 

--- a/mmm_audio/MMMAudioBridge.mojo
+++ b/mmm_audio/MMMAudioBridge.mojo
@@ -43,7 +43,7 @@ def PyInit_GrainsBridge() abi("C") -> PythonObject:
 struct MMMAudioBridge(Movable, Writable):
     var world: World
     var graph: Grains  # The audio graph instance
-    var environment: Optional[UnsafePointer[mut=True, Environment, MutUntrackedOrigin]]
+    var environment_ptr: UnsafePointer[mut=True, Environment, MutUntrackedOrigin]
 
     # def(args: PythonObject, kwargs: PythonObject) raises -> MMMAudioBridge
     @staticmethod
@@ -60,32 +60,32 @@ struct MMMAudioBridge(Movable, Writable):
     def __init__(out self, sample_rate: Float64 = 44100.0, block_size: Int = 512, num_in_chans: Int = 12, num_out_chans: Int = 12):
         """Initialize the audio engine with sample rate, block size, and number of channels."""
 
-        self.environment = alloc[Environment](1)
-        self.environment.value().init_pointee_move(Environment(block_size, num_in_chans, num_out_chans))
+        self.environment_ptr = alloc[Environment](1)
+        self.environment_ptr.init_pointee_move(Environment(block_size, num_in_chans, num_out_chans))
 
         self.world = alloc[MMMWorld](1) 
-        self.world.init_pointee_move(MMMWorld(sample_rate, self.environment))
+        self.world.init_pointee_move(MMMWorld(sample_rate, self.environment_ptr))
 
         self.graph = Grains(self.world)
 
     def write_to(self, mut writer: Some[Writer]):
-        writer.write("MMMAudioBridge with sample_rate=", self.world[].sample_rate, ", block_size=", self.world[].environment.value()[].block_size)
+        writer.write("MMMAudioBridge with sample_rate=", self.world[].sample_rate, ", block_size=", self.environment_ptr[].block_size)
 
     def write_repr_to(self, mut writer: Some[Writer]):
-        writer.write("MMMAudioBridge with sample_rate=", self.world[].sample_rate, ", block_size=", self.world[].environment.value()[].block_size)
+        writer.write("MMMAudioBridge with sample_rate=", self.world[].sample_rate, ", block_size=", self.environment_ptr[].block_size)
 
     @staticmethod
     def set_screen_dims(py_selfA: PythonObject, dims: PythonObject) raises -> PythonObject:
         var py_self = py_selfA.downcast_value_ptr[Self]()
-        py_self[0].world[].environment.value()[].screen_dims = [Float64(py=dims[0]), Float64(py=dims[1])]  # Set the screen size in the MMMWorld instance
+        py_self[].environment_ptr[].screen_dims = [Float64(py=dims[0]), Float64(py=dims[1])]  # Set the screen size in the MMMWorld instance
 
         return PythonObject(None) 
 
     @staticmethod
     def update_mouse_pos(py_selfA: PythonObject, pos: PythonObject) raises -> PythonObject:
         var py_self = py_selfA.downcast_value_ptr[Self]()
-        py_self[0].world[].environment.value()[].mouse_x = Float64(py=pos[0])
-        py_self[0].world[].environment.value()[].mouse_y = Float64(py=pos[1])
+        py_self[].environment_ptr[].mouse_x = Float64(py=pos[0])
+        py_self[].environment_ptr[].mouse_y = Float64(py=pos[1])
 
         return PythonObject(None)
 
@@ -96,8 +96,7 @@ struct MMMAudioBridge(Movable, Writable):
     @staticmethod
     def update_bool_msg(py_selfA: PythonObject, key_vals: PythonObject) raises -> PythonObject:
         var py_self = py_selfA.downcast_value_ptr[Self]()
-        temp = py_self[0].messenger_manager.value()
-        temp[].update_bool_msg(String(key_vals[0]), Bool(key_vals[1]))
+        py_self[].environment_ptr[].messenger_manager.update_bool_msg(String(key_vals[0]), Bool(key_vals[1]))
 
         return PythonObject(None)
 
@@ -107,15 +106,13 @@ struct MMMAudioBridge(Movable, Writable):
         key = String(key_vals[0])
         values = [Bool(b) for b in key_vals[1:]]
 
-        temp = py_self[0].messenger_manager.value()
-        temp[].update_bools_msg(key, values^)
+        py_self[].environment_ptr[].messenger_manager.update_bools_msg(key, values^)
         return PythonObject(None)
 
     @staticmethod
     def update_float_msg(py_selfA: PythonObject, key_vals: PythonObject) raises -> PythonObject:
         var py_self = py_selfA.downcast_value_ptr[Self]()
-        temp = py_self[0].messenger_manager.value()
-        temp[].update_float_msg(String(key_vals[0]), Float64(py=key_vals[1]))
+        py_self[].environment_ptr[].messenger_manager.update_float_msg(String(key_vals[0]), Float64(py=key_vals[1]))
 
         return PythonObject(None)
 
@@ -125,16 +122,15 @@ struct MMMAudioBridge(Movable, Writable):
         key = String(key_vals[0])
         values = [Float64(py=f) for f in key_vals[1:]]
 
-        temp = py_self[0].messenger_manager.value()
-        temp[].update_floats_msg(key, values^)
+        py_self[].environment_ptr[].messenger_manager.update_floats_msg(key, values^)
 
         return PythonObject(None)
 
     @staticmethod
     def update_int_msg(py_selfA: PythonObject, key_vals: PythonObject) raises -> PythonObject:
         var py_self = py_selfA.downcast_value_ptr[Self]()
-        temp = py_self[0].messenger_manager.value()
-        temp[].update_int_msg(String(key_vals[0]), Int(py=key_vals[1]))
+
+        py_self[].environment_ptr[].messenger_manager.update_int_msg(String(key_vals[0]), Int(py=key_vals[1]))
 
         return PythonObject(None)
 
@@ -144,16 +140,14 @@ struct MMMAudioBridge(Movable, Writable):
         key = String(key_vals[0])
         values = [Int(py=v) for v in key_vals[1:]]
 
-        temp = py_self[0].messenger_manager.value()
-        temp[].update_ints_msg(key, values^)
+        py_self[].environment_ptr[].messenger_manager.update_ints_msg(key, values^)
 
         return PythonObject(None)
 
     @staticmethod
     def update_trig_msg(py_selfA: PythonObject, key_vals: PythonObject) raises -> PythonObject:
         var py_self = py_selfA.downcast_value_ptr[Self]()
-        temp = py_self[0].messenger_manager.value()
-        temp[].update_trig_msg(String(key_vals[0]))
+        py_self[].environment_ptr[].messenger_manager.update_trig_msg(String(key_vals[0]))
 
         return PythonObject(None)
 
@@ -165,8 +159,7 @@ struct MMMAudioBridge(Movable, Writable):
         key = String(key_vals[0])
         values = [Bool(b) for b in key_vals[1:]]
 
-        temp = py_self[0].messenger_manager.value()
-        temp[].update_trigs_msg(key, values^)
+        py_self[].environment_ptr[].messenger_manager.update_trigs_msg(key, values^)
 
         return PythonObject(None)
 
@@ -175,8 +168,7 @@ struct MMMAudioBridge(Movable, Writable):
 
         var py_self = py_selfA.downcast_value_ptr[Self]()
 
-        temp = py_self[0].messenger_manager.value()
-        temp[].update_string_msg(String(key_vals[0]), String(key_vals[1]))
+        py_self[].environment_ptr[].messenger_manager.update_string_msg(String(key_vals[0]), String(key_vals[1]))
 
         return PythonObject(None)
 
@@ -188,36 +180,34 @@ struct MMMAudioBridge(Movable, Writable):
         key = String(key_vals[0])
         texts = [String(s) for s in key_vals[1:]]
 
-        temp = py_self[0].messenger_manager.value()
-        temp[].update_strings_msg(key, texts^)
+        py_self[].environment_ptr[].messenger_manager.update_strings_msg(key, texts^)
 
         return PythonObject(None)
 
     def get_audio_samples(mut self, loc_in_buffer: MutUnsafePointer[Float32, ...], mut loc_out_buffer: MutUnsafePointer[Float64, ...]) raises:
 
-        self.world[].environment.value()[].top_of_block = True
-        temp = self.messenger_manager.value()
-        temp[].transfer_msgs()
+        self.environment_ptr[].top_of_block = True
+        self.environment_ptr[].messenger_manager.transfer_msgs()
                 
-        for i in range(self.world[].environment.value()[].block_size):
-            self.world[].environment.value()[].block_state = i  # Update the block state
+        for i in range(self.environment_ptr[].block_size):
+            self.environment_ptr[].block_state = i  # Update the block state
 
             if i == 1:
-                self.world[].environment.value()[].top_of_block = False
-                temp[].empty_msg_dicts()
+                self.environment_ptr[].top_of_block = False
+                self.environment_ptr[].messenger_manager.empty_msg_dicts()
 
-            if self.world[].environment.value()[].top_of_block:
-                self.world[].environment.value()[].print_counter += 1
+            if self.environment_ptr[].top_of_block:
+                self.environment_ptr[].print_counter += 1
             # fill the sound_in list with the current sample from all inputs
-            for j in range(self.world[].environment.value()[].num_in_chans):
-                self.world[].environment.value()[].sound_in[j] = Float64(loc_in_buffer[i * self.world[].environment.value()[].num_in_chans + j]) 
+            for j in range(self.environment_ptr[].num_in_chans):
+                self.environment_ptr[].sound_in[j] = Float64(loc_in_buffer[i * self.environment_ptr[].num_in_chans + j]) 
 
             samples = self.graph.next()  # Get the next audio samples from the graph
 
             # Fill the wire buffer with the sample data
-            for j in range(min(self.world[].environment.value()[].num_out_chans, samples.__len__())):
-                loc_out_buffer[i * self.world[].environment.value()[].num_out_chans + j] = samples[Int(j)]
-                
+            for j in range(min(self.environment_ptr[].num_out_chans, samples.__len__())):
+                loc_out_buffer[i * self.environment_ptr[].num_out_chans + j] = samples[Int(j)]
+
     @staticmethod
     def next(py_selfA: PythonObject, in_buffer: PythonObject, out_buffer: PythonObject) raises -> PythonObject:
 
@@ -230,9 +220,9 @@ struct MMMAudioBridge(Movable, Writable):
         # zero the output buffer
         # TODO: is this necessary? aren't they going to be overwritten anyway?
         # if they're not overwritten wouldn't that be a bug?
-        for j in range(py_self[0].world[].environment.value()[].num_out_chans):
-            for i in range(py_self[0].world[].environment.value()[].block_size):
-                loc_out_buffer[i * py_self[0].world[].environment.value()[].num_out_chans + j] = 0.0 
+        for j in range(py_self[].environment_ptr[].num_out_chans):
+            for i in range(py_self[].environment_ptr[].block_size):
+                loc_out_buffer[i * py_self[].environment_ptr[].num_out_chans + j] = 0.0 
 
         py_self[0].get_audio_samples(loc_in_buffer, loc_out_buffer)
 

--- a/mmm_audio/MMMAudioBridge.mojo
+++ b/mmm_audio/MMMAudioBridge.mojo
@@ -32,7 +32,6 @@ def PyInit_GrainsBridge() abi("C") -> PythonObject:
             .def_method[MMMAudioBridge.update_trigs_msg]("update_trigs_msg")
             .def_method[MMMAudioBridge.update_string_msg]("update_string_msg")
             .def_method[MMMAudioBridge.update_strings_msg]("update_strings_msg")
-            .def_method[MMMAudioBridge.set_channel_count]("set_channel_count")  
 
         return m.finalize()
     except e:
@@ -44,11 +43,7 @@ def PyInit_GrainsBridge() abi("C") -> PythonObject:
 struct MMMAudioBridge(Movable, Writable):
     var world: World
     var graph: Grains  # The audio graph instance
-    var world_info: Optional[UnsafePointer[mut=True, WorldInfo, MutUntrackedOrigin]]
-    var osc_buffers: Optional[UnsafePointer[mut=True, OscBuffers, MutUntrackedOrigin]] 
-    var windows: Optional[UnsafePointer[mut=True, Windows, MutUntrackedOrigin]]
-    var messenger_manager: Optional[UnsafePointer[mut=True, MessengerManager, MutUntrackedOrigin]] 
-    var sinc_interpolator: Optional[UnsafePointer[mut=True, SincInterpolator[4, 14], MutUntrackedOrigin]]
+    var environment: Optional[UnsafePointer[mut=True, Environment, MutUntrackedOrigin]]
 
     # def(args: PythonObject, kwargs: PythonObject) raises -> MMMAudioBridge
     @staticmethod
@@ -60,61 +55,39 @@ struct MMMAudioBridge(Movable, Writable):
         var num_out_chans: Int = 2
         var num_in_chans: Int = 2
 
-        # right now if you try to read args[3], shit gets really weird
-
-        self = Self(sample_rate, block_size, num_in_chans, num_out_chans)  # Initialize with sample rate, block size, and number of channels
+        self = Self(sample_rate, block_size, num_in_chans, num_out_chans)
 
     def __init__(out self, sample_rate: Float64 = 44100.0, block_size: Int = 512, num_in_chans: Int = 12, num_out_chans: Int = 12):
         """Initialize the audio engine with sample rate, block size, and number of channels."""
 
-        self.osc_buffers = alloc[OscBuffers](1)
-        self.osc_buffers.value().init_pointee_move(OscBuffers())
-        self.windows = alloc[Windows](1)
-        self.windows.value().init_pointee_move(Windows())
-        self.sinc_interpolator = alloc[SincInterpolator[4, 14]](1)
-        self.sinc_interpolator.value().init_pointee_move(SincInterpolator[4, 14]())
-
-        self.messenger_manager = alloc[MessengerManager](1)
-        self.messenger_manager.value().init_pointee_move(MessengerManager())
-
-        self.world_info = alloc[WorldInfo](1)
-        self.world_info.value().init_pointee_move(WorldInfo(block_size, num_in_chans, num_out_chans))
+        self.environment = alloc[Environment](1)
+        self.environment.value().init_pointee_move(Environment(block_size, num_in_chans, num_out_chans))
 
         self.world = alloc[MMMWorld](1) 
-        self.world.init_pointee_move(MMMWorld(sample_rate, self.world_info, self.osc_buffers, self.windows, self.messenger_manager, self.sinc_interpolator))
+        self.world.init_pointee_move(MMMWorld(sample_rate, self.environment))
 
         self.graph = Grains(self.world)
 
     def write_to(self, mut writer: Some[Writer]):
-        writer.write("MMMAudioBridge with sample_rate=", self.world[].sample_rate, ", block_size=", self.world[].world_info.value()[].block_size)
+        writer.write("MMMAudioBridge with sample_rate=", self.world[].sample_rate, ", block_size=", self.world[].environment.value()[].block_size)
 
     def write_repr_to(self, mut writer: Some[Writer]):
-        writer.write("MMMAudioBridge with sample_rate=", self.world[].sample_rate, ", block_size=", self.world[].world_info.value()[].block_size)
-
-    @staticmethod
-    def set_channel_count(py_selfA: PythonObject, args: PythonObject) raises -> PythonObject:
-        var num_in_chans = Int(py=args[0])
-        var num_out_chans = Int(py=args[1])
-        print("set_channel_count:", num_in_chans, num_out_chans)
-        var py_self = py_selfA.downcast_value_ptr[Self]()
-        py_self[0].world[].set_channel_count(num_in_chans, num_out_chans)
-    
-        return None # PythonObject(None)
+        writer.write("MMMAudioBridge with sample_rate=", self.world[].sample_rate, ", block_size=", self.world[].environment.value()[].block_size)
 
     @staticmethod
     def set_screen_dims(py_selfA: PythonObject, dims: PythonObject) raises -> PythonObject:
         var py_self = py_selfA.downcast_value_ptr[Self]()
-        py_self[0].world[].world_info.value()[].screen_dims = [Float64(py=dims[0]), Float64(py=dims[1])]  # Set the screen size in the MMMWorld instance
+        py_self[0].world[].environment.value()[].screen_dims = [Float64(py=dims[0]), Float64(py=dims[1])]  # Set the screen size in the MMMWorld instance
 
         return PythonObject(None) 
 
     @staticmethod
     def update_mouse_pos(py_selfA: PythonObject, pos: PythonObject) raises -> PythonObject:
         var py_self = py_selfA.downcast_value_ptr[Self]()
-        py_self[0].world[].world_info.value()[].mouse_x = Float64(py=pos[0])
-        py_self[0].world[].world_info.value()[].mouse_y = Float64(py=pos[1])
+        py_self[0].world[].environment.value()[].mouse_x = Float64(py=pos[0])
+        py_self[0].world[].environment.value()[].mouse_y = Float64(py=pos[1])
 
-        return PythonObject(None)  # Return a PythonObject wrapping None
+        return PythonObject(None)
 
     @staticmethod
     def to_float64(py_float: PythonObject) raises -> Float64:
@@ -126,7 +99,7 @@ struct MMMAudioBridge(Movable, Writable):
         temp = py_self[0].messenger_manager.value()
         temp[].update_bool_msg(String(key_vals[0]), Bool(key_vals[1]))
 
-        return PythonObject(None)  # Return a PythonObject wrapping None
+        return PythonObject(None)
 
     @staticmethod
     def update_bools_msg(py_selfA: PythonObject, key_vals: PythonObject) raises -> PythonObject:
@@ -136,7 +109,7 @@ struct MMMAudioBridge(Movable, Writable):
 
         temp = py_self[0].messenger_manager.value()
         temp[].update_bools_msg(key, values^)
-        return PythonObject(None)  # Return a PythonObject wrapping None
+        return PythonObject(None)
 
     @staticmethod
     def update_float_msg(py_selfA: PythonObject, key_vals: PythonObject) raises -> PythonObject:
@@ -144,7 +117,7 @@ struct MMMAudioBridge(Movable, Writable):
         temp = py_self[0].messenger_manager.value()
         temp[].update_float_msg(String(key_vals[0]), Float64(py=key_vals[1]))
 
-        return PythonObject(None)  # Return a PythonObject wrapping None
+        return PythonObject(None)
 
     @staticmethod
     def update_floats_msg(py_selfA: PythonObject, key_vals: PythonObject) raises -> PythonObject:
@@ -155,7 +128,7 @@ struct MMMAudioBridge(Movable, Writable):
         temp = py_self[0].messenger_manager.value()
         temp[].update_floats_msg(key, values^)
 
-        return PythonObject(None)  # Return a PythonObject wrapping None
+        return PythonObject(None)
 
     @staticmethod
     def update_int_msg(py_selfA: PythonObject, key_vals: PythonObject) raises -> PythonObject:
@@ -163,7 +136,7 @@ struct MMMAudioBridge(Movable, Writable):
         temp = py_self[0].messenger_manager.value()
         temp[].update_int_msg(String(key_vals[0]), Int(py=key_vals[1]))
 
-        return PythonObject(None)  # Return a PythonObject wrapping None
+        return PythonObject(None)
 
     @staticmethod
     def update_ints_msg(py_selfA: PythonObject, key_vals: PythonObject) raises -> PythonObject:
@@ -174,7 +147,7 @@ struct MMMAudioBridge(Movable, Writable):
         temp = py_self[0].messenger_manager.value()
         temp[].update_ints_msg(key, values^)
 
-        return PythonObject(None)  # Return a PythonObject wrapping None
+        return PythonObject(None)
 
     @staticmethod
     def update_trig_msg(py_selfA: PythonObject, key_vals: PythonObject) raises -> PythonObject:
@@ -182,7 +155,7 @@ struct MMMAudioBridge(Movable, Writable):
         temp = py_self[0].messenger_manager.value()
         temp[].update_trig_msg(String(key_vals[0]))
 
-        return PythonObject(None)  # Return a PythonObject wrapping None
+        return PythonObject(None)
 
     @staticmethod
     def update_trigs_msg(py_selfA: PythonObject, key_vals: PythonObject) raises -> PythonObject:
@@ -195,7 +168,7 @@ struct MMMAudioBridge(Movable, Writable):
         temp = py_self[0].messenger_manager.value()
         temp[].update_trigs_msg(key, values^)
 
-        return PythonObject(None)  # Return a PythonObject wrapping None
+        return PythonObject(None)
 
     @staticmethod
     def update_string_msg(py_selfA: PythonObject, key_vals: PythonObject) raises -> PythonObject:
@@ -205,7 +178,7 @@ struct MMMAudioBridge(Movable, Writable):
         temp = py_self[0].messenger_manager.value()
         temp[].update_string_msg(String(key_vals[0]), String(key_vals[1]))
 
-        return PythonObject(None)  # Return a PythonObject wrapping None
+        return PythonObject(None)
 
     @staticmethod
     def update_strings_msg(py_selfA: PythonObject, key_vals: PythonObject) raises -> PythonObject:
@@ -218,32 +191,33 @@ struct MMMAudioBridge(Movable, Writable):
         temp = py_self[0].messenger_manager.value()
         temp[].update_strings_msg(key, texts^)
 
-        return PythonObject(None)  # Return a PythonObject wrapping None
+        return PythonObject(None)
 
     def get_audio_samples(mut self, loc_in_buffer: MutUnsafePointer[Float32, ...], mut loc_out_buffer: MutUnsafePointer[Float64, ...]) raises:
 
-        self.world[].world_info.value()[].top_of_block = True
+        self.world[].environment.value()[].top_of_block = True
         temp = self.messenger_manager.value()
         temp[].transfer_msgs()
                 
-        for i in range(self.world[].world_info.value()[].block_size):
-            self.world[].world_info.value()[].block_state = i  # Update the block state
+        for i in range(self.world[].environment.value()[].block_size):
+            self.world[].environment.value()[].block_state = i  # Update the block state
 
             if i == 1:
-                self.world[].world_info.value()[].top_of_block = False
+                self.world[].environment.value()[].top_of_block = False
                 temp[].empty_msg_dicts()
 
-            if self.world[].world_info.value()[].top_of_block:
-                self.world[].world_info.value()[].print_counter += 1
+            if self.world[].environment.value()[].top_of_block:
+                self.world[].environment.value()[].print_counter += 1
             # fill the sound_in list with the current sample from all inputs
-            for j in range(self.world[].world_info.value()[].num_in_chans):
-                self.world[].world_info.value()[].sound_in[j] = Float64(loc_in_buffer[i * self.world[].world_info.value()[].num_in_chans + j]) 
+            for j in range(self.world[].environment.value()[].num_in_chans):
+                self.world[].environment.value()[].sound_in[j] = Float64(loc_in_buffer[i * self.world[].environment.value()[].num_in_chans + j]) 
 
             samples = self.graph.next()  # Get the next audio samples from the graph
 
             # Fill the wire buffer with the sample data
-            for j in range(min(self.world[].world_info.value()[].num_out_chans, samples.__len__())):
-                loc_out_buffer[i * self.world[].world_info.value()[].num_out_chans + j] = samples[Int(j)]
+            for j in range(min(self.world[].environment.value()[].num_out_chans, samples.__len__())):
+                loc_out_buffer[i * self.world[].environment.value()[].num_out_chans + j] = samples[Int(j)]
+                
     @staticmethod
     def next(py_selfA: PythonObject, in_buffer: PythonObject, out_buffer: PythonObject) raises -> PythonObject:
 
@@ -254,10 +228,12 @@ struct MMMAudioBridge(Movable, Writable):
         loc_out_buffer = out_buffer.__array_interface__["data"][0].unsafe_get_as_pointer[DType.float64]()
 
         # zero the output buffer
-        for j in range(py_self[0].world[].world_info.value()[].num_out_chans):
-            for i in range(py_self[0].world[].world_info.value()[].block_size):
-                loc_out_buffer[i * py_self[0].world[].world_info.value()[].num_out_chans + j] = 0.0 
+        # TODO: is this necessary? aren't they going to be overwritten anyway?
+        # if they're not overwritten wouldn't that be a bug?
+        for j in range(py_self[0].world[].environment.value()[].num_out_chans):
+            for i in range(py_self[0].world[].environment.value()[].block_size):
+                loc_out_buffer[i * py_self[0].world[].environment.value()[].num_out_chans + j] = 0.0 
 
-        py_self[0].get_audio_samples(loc_in_buffer, loc_out_buffer)  
+        py_self[0].get_audio_samples(loc_in_buffer, loc_out_buffer)
 
-        return PythonObject(None)  # Return a PythonObject wrapping the float value
+        return PythonObject(None)

--- a/mmm_audio/MMMWorld_Module.mojo
+++ b/mmm_audio/MMMWorld_Module.mojo
@@ -51,8 +51,40 @@ struct MMMWorld(Movable, Copyable):
     var sample_rate: Float64
     var environment_ptr: Optional[UnsafePointer[mut=True, Environment, MutUntrackedOrigin]]
 
+    def windows(self) -> ref[self.environment_ptr.value()[].windows] Windows:
+        """Returns a reference to the Windows struct for accessing predefined windows.
+
+        Returns:
+            A reference to the Windows struct.
+        """
+        return self.environment_ptr.value()[].windows
+
+    def sinc_interpolator(self) -> ref[self.environment_ptr.value()[].sinc_interpolator] SincInterpolator[4, 14]:
+        """Returns a reference to the SincInterpolator struct for performing sinc interpolation.
+
+        Returns:
+            A reference to the SincInterpolator struct.
+        """
+        return self.environment_ptr.value()[].sinc_interpolator
+
+    def osc_buffers(self) -> ref[self.environment_ptr.value()[].osc_buffers] OscBuffers:
+        """Returns a reference to the OscBuffers struct for accessing oscillator buffers.
+
+        Returns:
+            A reference to the OscBuffers struct.
+        """
+        return self.environment_ptr.value()[].osc_buffers
+
+    def messenger_manager(self) -> ref[self.environment_ptr.value()[].messenger_manager] MessengerManager:
+        """Returns a reference to the MessengerManager struct for managing messages.
+
+        Returns:
+            A reference to the MessengerManager struct.
+        """
+        return self.environment_ptr.value()[].messenger_manager
+
     def __init__(out self, sample_rate: Float64,
-        environment_ptr: Optional[UnsafePointer[Environment, MutUntrackedOrigin]] = None,
+        environment_ptr: Optional[UnsafePointer[mut=True, Environment, MutUntrackedOrigin]] = None,
     ):
         """Initializes the MMMWorld struct.
 
@@ -77,8 +109,8 @@ struct MMMWorld(Movable, Copyable):
         Returns:
             The current mouse x position as a value between 0.0 and 1.0.
         """
-        if self.environment.value():
-            return self.environment.value()[].mouse_x
+        if self.environment_ptr:
+            return self.environment_ptr.value()[].mouse_x
         
         print("Warning: Environment pointer is None. Returning default mouse_x value of 0.0.")
         return 0.0
@@ -89,8 +121,8 @@ struct MMMWorld(Movable, Copyable):
         Returns:
             The current mouse y position as a value between 0.0 and 1.0.
         """
-        if self.environment.value():
-            return self.environment.value()[].mouse_y
+        if self.environment_ptr:
+            return self.environment_ptr.value()[].mouse_y
         
         print("Warning: Environment pointer is None. Returning default mouse_y value of 0.0.")
         return 0.0
@@ -101,8 +133,8 @@ struct MMMWorld(Movable, Copyable):
         Returns:
             True if the current sample is the first sample of the audio block, false otherwise.
         """
-        if self.environment.value():
-            return self.environment.value()[].top_of_block
+        if self.environment_ptr:
+            return self.environment_ptr.value()[].top_of_block
 
         print("Warning: Environment pointer is None. Returning default top_of_block value of False.")
         return False
@@ -113,8 +145,8 @@ struct MMMWorld(Movable, Copyable):
         Returns:
             An integer that increments by 1 at the start of each audio block. Resets to 0 after reaching 2^31 - 1.
         """
-        if self.environment.value():
-            return self.environment.value()[].block_state
+        if self.environment_ptr:
+            return self.environment_ptr.value()[].block_state
 
         print("Warning: Environment pointer is None. Returning default block_state value of 0.")
         return 0
@@ -125,8 +157,8 @@ struct MMMWorld(Movable, Copyable):
         Returns:
             The number of input channels.
         """
-        if self.environment.value():
-            return self.environment.value()[].num_in_chans
+        if self.environment_ptr:
+            return self.environment_ptr.value()[].num_in_chans
 
         print("Warning: Environment pointer is None. Returning default num_in_chans value of 0.")
         return 0
@@ -138,8 +170,8 @@ struct MMMWorld(Movable, Copyable):
             The number of output channels.
         """
 
-        if self.environment.value():
-            return self.environment.value()[].num_out_chans
+        if self.environment_ptr:
+            return self.environment_ptr.value()[].num_out_chans
 
         print("Warning: Environment pointer is None. Returning default num_out_chans value of 0.")
         return 0
@@ -154,8 +186,8 @@ struct MMMWorld(Movable, Copyable):
             The input sample value for the given channel.
         """
 
-        if self.environment.value():
-            return self.environment.value()[].sound_in[chan]
+        if self.environment_ptr:
+            return self.environment_ptr.value()[].sound_in[chan]
 
         print("Warning: Environment pointer is None. Returning default sound_in value of 0.0.")
         return 0.0
@@ -174,13 +206,31 @@ struct MMMWorld(Movable, Copyable):
             end: End string to print after all values. Must be specified using the keyword argument.
         """
         
-        if self.environment.value():
-            if self.environment.value()[].top_of_block:
-                if self.environment.value()[].print_counter % n_blocks == 0:
-                    comptime for i in range(values.__len__()):
-                        print(values[i], end=sep if i < values.__len__() - 1 else end)
+        if self.environment_ptr:
+            if self.environment_ptr.value()[].top_of_block and self.environment_ptr.value()[].print_counter % n_blocks == 0:
+                comptime for i in range(values.__len__()):
+                    print(values[i], end=sep if i < values.__len__() - 1 else end)
 
         print("Warning: Environment pointer is None. Cannot print values.")
+
+    def create_subworld(self, times_ov_samp: TimesOversampling = TimesOversampling.none) -> UnsafePointer[MMMWorld, MutUntrackedOrigin]:
+        """Create another MMMWorld instance using a different TimesOversampling.
+
+        This is mostly used to create an oversampled subworld with a higher sample rate based on the main world.
+
+        Args:
+            times_ov_samp: A [TimesOversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
+
+        Returns:
+            A pointer to the newly created MMMWorld struct.
+        """
+        new_world = alloc[MMMWorld](1) 
+        new_world.init_pointee_move(MMMWorld(
+            sample_rate=self.sample_rate * Float64(times_ov_samp.times), 
+            environment_ptr = self.environment_ptr
+        ))
+
+        return new_world
 
 @fieldwise_init
 struct Interp(Equatable, ImplicitlyCopyable):

--- a/mmm_audio/MMMWorld_Module.mojo
+++ b/mmm_audio/MMMWorld_Module.mojo
@@ -3,7 +3,7 @@ import std.time
 from std.collections import Set
 from mmm_audio import *
 
-struct WorldInfo(Movable, Copyable):
+struct Environment(Movable, Copyable):
     var block_size: Int
     var num_in_chans: Int
     var num_out_chans: Int
@@ -17,6 +17,11 @@ struct WorldInfo(Movable, Copyable):
     var print_flag: Int
     var last_print_flag: Int
     var print_counter: UInt16
+
+    var osc_buffers: OscBuffers
+    var windows: Windows
+    var messenger_manager: MessengerManager
+    var sinc_interpolator: SincInterpolator[4, 14]
 
     def __init__(out self, block_size: Int = 64, num_in_chans: Int = 2, num_out_chans: Int = 2):
         self.block_size = block_size
@@ -33,17 +38,10 @@ struct WorldInfo(Movable, Copyable):
         self.last_print_flag = 0
         self.print_counter = 0
 
-    def update_input(mut self, input_buffer: UnsafePointer[mut=True, Float64, MutUntrackedOrigin]):
-        """Updates the input buffer values in the WorldInfo struct.
-
-        This should be called at the beginning of each audio block to update the input buffer values from the host DAW.
-
-        Args:
-            input_buffer: A pointer to the input buffer provided by the host DAW. The buffer is interleaved and has a length of block_size * num_in_chans.
-        """
-        for chan in range(self.num_in_chans):
-            for i in range(self.block_size):
-                self.sound_in[chan] = input_buffer[i * self.num_in_chans + chan]
+        self.osc_buffers = OscBuffers()
+        self.windows = Windows()
+        self.sinc_interpolator = SincInterpolator[4, 14]()
+        self.messenger_manager = MessengerManager()
 
 struct MMMWorld(Movable, Copyable):
     """The MMMWorld struct holds global audio processing parameters and state.
@@ -51,40 +49,27 @@ struct MMMWorld(Movable, Copyable):
     In pretty much all usage, don't edit this struct.
     """
     var sample_rate: Float64
-    var world_info: Optional[UnsafePointer[mut=True, WorldInfo, MutUntrackedOrigin]]
-    var osc_buffers: Optional[UnsafePointer[mut=True, OscBuffers, MutUntrackedOrigin]]
-    # windows
-    var windows: Optional[UnsafePointer[mut=True, Windows, MutUntrackedOrigin]]
-    var messenger_manager: Optional[UnsafePointer[mut=True, MessengerManager, MutUntrackedOrigin]]
-    var sinc_interpolator: Optional[UnsafePointer[mut=True, SincInterpolator[4, 14], MutUntrackedOrigin]]
+    var environment_ptr: Optional[UnsafePointer[mut=True, Environment, MutUntrackedOrigin]]
 
     def __init__(out self, sample_rate: Float64,
-        world_info_ptr: Optional[UnsafePointer[WorldInfo, MutUntrackedOrigin]] = None,
-        osc_buffers_ptr: Optional[UnsafePointer[OscBuffers, MutUntrackedOrigin]] = None, 
-        windows_ptr: Optional[UnsafePointer[Windows, MutUntrackedOrigin]] = None, 
-        messenger_manager_ptr: Optional[UnsafePointer[MessengerManager, MutUntrackedOrigin]] = None,
-        sinc_interpolator_ptr: Optional[UnsafePointer[SincInterpolator[4, 14], MutUntrackedOrigin]] = None
+        environment_ptr: Optional[UnsafePointer[Environment, MutUntrackedOrigin]] = None,
     ):
         """Initializes the MMMWorld struct.
 
         Args:
             sample_rate: The audio sample rate.
-            world_info_ptr: A pointer to the WorldInfo struct, which holds information about the current audio block and input buffers.
-            osc_buffers_ptr: A pointer to the OscBuffers struct, which holds precomputed oscillator waveforms.
-            windows_ptr: A pointer to the Windows struct, which holds precomputed window functions.
-            messenger_manager_ptr: A pointer to the MessengerManager struct.
-            sinc_interpolator_ptr: A pointer to the SincInterpolator struct.
+            environment_ptr: A pointer to the Environment struct, which holds information about the current audio block and input buffers.
         """
         
         self.sample_rate = sample_rate
-        self.world_info = world_info_ptr
-        self.osc_buffers = osc_buffers_ptr
-        self.windows = windows_ptr
-        self.messenger_manager = messenger_manager_ptr
-        self.sinc_interpolator = sinc_interpolator_ptr
+        self.environment_ptr = environment_ptr
 
-        if self.world_info != None:
-            print("MMMWorld initialized with sample rate:", self.sample_rate, "and block size:", self.world_info.value()[].block_size)
+        print("MMMWorld initialized with sample rate:", self.sample_rate)
+        if self.environment_ptr != None:
+            print("Environment pointer is set.")
+        else:
+            print("Environment pointer is not set.")
+
 
     def mouse_x(self) -> Float64:
         """Returns the current mouse x position as a value between 0.0 and 1.0.
@@ -92,7 +77,11 @@ struct MMMWorld(Movable, Copyable):
         Returns:
             The current mouse x position as a value between 0.0 and 1.0.
         """
-        return self.world_info.value()[].mouse_x
+        if self.environment.value():
+            return self.environment.value()[].mouse_x
+        
+        print("Warning: Environment pointer is None. Returning default mouse_x value of 0.0.")
+        return 0.0
 
     def mouse_y(self) -> Float64:
         """Returns the current mouse y position as a value between 0.0 and 1.0.
@@ -100,7 +89,11 @@ struct MMMWorld(Movable, Copyable):
         Returns:
             The current mouse y position as a value between 0.0 and 1.0.
         """
-        return self.world_info.value()[].mouse_y
+        if self.environment.value():
+            return self.environment.value()[].mouse_y
+        
+        print("Warning: Environment pointer is None. Returning default mouse_y value of 0.0.")
+        return 0.0
 
     def top_of_block(self) -> Bool:
         """Returns true if the current sample is the first sample of the audio block.
@@ -108,7 +101,11 @@ struct MMMWorld(Movable, Copyable):
         Returns:
             True if the current sample is the first sample of the audio block, false otherwise.
         """
-        return self.world_info.value()[].top_of_block
+        if self.environment.value():
+            return self.environment.value()[].top_of_block
+
+        print("Warning: Environment pointer is None. Returning default top_of_block value of False.")
+        return False
     
     def block_state(self) -> Int:
         """Returns the block state.
@@ -116,7 +113,11 @@ struct MMMWorld(Movable, Copyable):
         Returns:
             An integer that increments by 1 at the start of each audio block. Resets to 0 after reaching 2^31 - 1.
         """
-        return self.world_info.value()[].block_state
+        if self.environment.value():
+            return self.environment.value()[].block_state
+
+        print("Warning: Environment pointer is None. Returning default block_state value of 0.")
+        return 0
 
     def num_in_chans(self) -> Int:
         """Returns the number of input channels.
@@ -124,7 +125,11 @@ struct MMMWorld(Movable, Copyable):
         Returns:
             The number of input channels.
         """
-        return self.world_info.value()[].num_in_chans
+        if self.environment.value():
+            return self.environment.value()[].num_in_chans
+
+        print("Warning: Environment pointer is None. Returning default num_in_chans value of 0.")
+        return 0
 
     def num_out_chans(self) -> Int:
         """Returns the number of output channels.
@@ -132,7 +137,12 @@ struct MMMWorld(Movable, Copyable):
         Returns:
             The number of output channels.
         """
-        return self.world_info.value()[].num_out_chans
+
+        if self.environment.value():
+            return self.environment.value()[].num_out_chans
+
+        print("Warning: Environment pointer is None. Returning default num_out_chans value of 0.")
+        return 0
 
     def sound_in(self, chan: Int) -> Float64:
         """Returns the input sample value for a given channel.
@@ -143,31 +153,12 @@ struct MMMWorld(Movable, Copyable):
         Returns:
             The input sample value for the given channel.
         """
-        return self.world_info.value()[].sound_in[chan]
 
-    def sound_in_ptr(self) -> Pointer[mut=True, List[Float64], MutUntrackedOrigin]:
-        """Returns a pointer to the input buffer values.
+        if self.environment.value():
+            return self.environment.value()[].sound_in[chan]
 
-        The buffer is interleaved and has a length of block_size * num_in_chans.
-        This is for advanced users who want to read the input buffer values directly from the pointer instead of using the sound_in(chan) method.
-
-        Returns:
-            A pointer to the input buffer values.
-        """
-        return Pointer(to=self.world_info.value()[].sound_in)
-
-    def set_channel_count(mut self, num_in_chans: Int, num_out_chans: Int):
-        """Sets the number of input and output channels.
-
-        Args:
-            num_in_chans: The number of input channels.
-            num_out_chans: The number of output channels.
-        """
-        self.world_info.value()[].num_in_chans = num_in_chans
-        self.world_info.value()[].num_out_chans = num_out_chans
-        self.world_info.value()[].sound_in = List[Float64]()
-        for _ in range(self.world_info.value()[].num_in_chans):
-            self.world_info.value()[].sound_in.append(0.0)  # Reinitialize input buffer with zeros
+        print("Warning: Environment pointer is None. Returning default sound_in value of 0.0.")
+        return 0.0
 
     @always_inline
     def print[*Ts: Writable](self, *values: *Ts, n_blocks: UInt16 = 10, sep: StringSlice[StaticConstantOrigin] = " ", end: StringSlice[StaticConstantOrigin] = "\n") -> None:
@@ -183,10 +174,13 @@ struct MMMWorld(Movable, Copyable):
             end: End string to print after all values. Must be specified using the keyword argument.
         """
         
-        if self.world_info.value()[].top_of_block:
-            if self.world_info.value()[].print_counter % n_blocks == 0:
-                comptime for i in range(values.__len__()):
-                    print(values[i], end=sep if i < values.__len__() - 1 else end)
+        if self.environment.value():
+            if self.environment.value()[].top_of_block:
+                if self.environment.value()[].print_counter % n_blocks == 0:
+                    comptime for i in range(values.__len__()):
+                        print(values[i], end=sep if i < values.__len__() - 1 else end)
+
+        print("Warning: Environment pointer is None. Cannot print values.")
 
 @fieldwise_init
 struct Interp(Equatable, ImplicitlyCopyable):

--- a/mmm_audio/Messenger_Module.mojo
+++ b/mmm_audio/Messenger_Module.mojo
@@ -63,8 +63,8 @@ struct Messenger(Copyable, Movable):
         """
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                var opt = temp[].get_bool(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                var opt = temp.get_bool(self.get_name_with_namespace(name)[])
                 if opt:
                     param = opt.value()
             except error:
@@ -83,8 +83,8 @@ struct Messenger(Copyable, Movable):
         """
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                var opt = temp[].get_bool(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                var opt = temp.get_bool(self.get_name_with_namespace(name)[])
                 if opt:
                     param = opt.value()
                     return True
@@ -125,8 +125,8 @@ struct Messenger(Copyable, Movable):
         
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                var opt = temp[].get_float(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                var opt = temp.get_float(self.get_name_with_namespace(name)[])
                 if opt:
                     param = opt.value()
             except error:
@@ -145,8 +145,8 @@ struct Messenger(Copyable, Movable):
         """
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                var opt = temp[].get_float(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                var opt = temp.get_float(self.get_name_with_namespace(name)[])
                 if opt:
                     param = opt.value()
                     return True
@@ -164,8 +164,8 @@ struct Messenger(Copyable, Movable):
         """
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                var opt = temp[].get_floats(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                var opt = temp.get_floats(self.get_name_with_namespace(name)[])
                 if opt:
                     param = opt.value().copy()
             except error:
@@ -184,8 +184,8 @@ struct Messenger(Copyable, Movable):
         """
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                var opt = temp[].get_floats(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                var opt = temp.get_floats(self.get_name_with_namespace(name)[])
                 if opt:
                     param = opt.value().copy()
                     return True
@@ -206,8 +206,8 @@ struct Messenger(Copyable, Movable):
         """
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                var opt = temp[].get_floats(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                var opt = temp.get_floats(self.get_name_with_namespace(name)[])
                 if opt:
                     for i in range(len(opt.value())):
                         param[i] = Scalar[dtype](opt.value()[i])
@@ -230,8 +230,8 @@ struct Messenger(Copyable, Movable):
         """
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                var opt = temp[].get_floats(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                var opt = temp.get_floats(self.get_name_with_namespace(name)[])
                 if opt:
                     for i in range(len(opt.value())):
                         param[i] = Scalar[dtype](opt.value()[i])
@@ -250,8 +250,8 @@ struct Messenger(Copyable, Movable):
         """
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                var opt = temp[].get_int(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                var opt = temp.get_int(self.get_name_with_namespace(name)[])
                 if opt:
                     param = opt.value()
             except error:
@@ -270,8 +270,8 @@ struct Messenger(Copyable, Movable):
         """
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                var opt = temp[].get_int(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                var opt = temp.get_int(self.get_name_with_namespace(name)[])
                 if opt:
                     param = opt.value()
                     return True
@@ -289,8 +289,8 @@ struct Messenger(Copyable, Movable):
         """
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                var opt = temp[].get_ints(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                var opt = temp.get_ints(self.get_name_with_namespace(name)[])
                 if opt:
                     param = opt.value().copy()
             except error:
@@ -309,8 +309,8 @@ struct Messenger(Copyable, Movable):
         """
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                var opt = temp[].get_ints(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                var opt = temp.get_ints(self.get_name_with_namespace(name)[])
                 if opt:
                     param = opt.value().copy()
                     return True
@@ -328,8 +328,8 @@ struct Messenger(Copyable, Movable):
         """
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                var opt = temp[].get_string(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                var opt = temp.get_string(self.get_name_with_namespace(name)[])
                 if opt:
                     param = opt.value()
             except error:
@@ -348,8 +348,8 @@ struct Messenger(Copyable, Movable):
         """
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                var opt = temp[].get_string(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                var opt = temp.get_string(self.get_name_with_namespace(name)[])
                 if opt:
                     param = opt.value()
                     return True
@@ -367,8 +367,8 @@ struct Messenger(Copyable, Movable):
         """
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                var opt = temp[].get_strings(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                var opt = temp.get_strings(self.get_name_with_namespace(name)[])
                 if opt:
                     param = opt.value().copy()
             except error:
@@ -387,8 +387,8 @@ struct Messenger(Copyable, Movable):
         """
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                var opt = temp[].get_strings(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                var opt = temp.get_strings(self.get_name_with_namespace(name)[])
                 if opt:
                     param = opt.value().copy()
                     return True
@@ -408,8 +408,8 @@ struct Messenger(Copyable, Movable):
 
         if self.world[].top_of_block():
             try:
-                temp = self.world[].messenger_manager.value()
-                return temp[].get_trig(self.get_name_with_namespace(name)[])
+                ref temp = self.world[].messenger_manager()
+                return temp.get_trig(self.get_name_with_namespace(name)[])
             except error:
                 print("Error occurred while updating trig message. Error: ", error)
         return False

--- a/mmm_audio/Oscillators.mojo
+++ b/mmm_audio/Oscillators.mojo
@@ -187,7 +187,7 @@ struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, ov_samp: TimesOve
             self.phasor = Phasor[self.num_chans](world)
             self.downsampler = None
         else:
-            oversampled_world = create_subworld(world, Self.ov_samp)
+            oversampled_world = world[].create_subworld(Self.ov_samp)
             self.phasor = Phasor[self.num_chans](oversampled_world)
             self.downsampler = Downsampler[self.num_chans, Self.ov_samp](world)
 
@@ -221,9 +221,9 @@ struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, ov_samp: TimesOve
 
         comptime if Self.ov_samp == TimesOversampling.none:
             phase = self.phasor.next(freq, phase_offset, trig_mask)
-            temp = self.world[].osc_buffers.value()
+            ref temp = self.world[].osc_buffers()
             comptime for chan in range(self.num_chans):
-                out[chan] = temp[].at_phase[osc_type, self.interp](self.world, phase[chan], self.last_phase[chan])
+                out[chan] = temp.at_phase[osc_type, self.interp](self.world, phase[chan], self.last_phase[chan])
             self.last_phase = phase
             return out
         else:
@@ -231,9 +231,9 @@ struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, ov_samp: TimesOve
                 phase = self.phasor.next(freq, phase_offset, trig_mask)
 
                 sample = MFloat[self.num_chans](0.0)
-                temp = self.world[].osc_buffers.value()
+                ref temp = self.world[].osc_buffers()
                 comptime for chan in range(self.num_chans):
-                    sample[chan] = temp[].at_phase[osc_type, self.interp](self.world, phase[chan], self.last_phase[chan])
+                    sample[chan] = temp.at_phase[osc_type, self.interp](self.world, phase[chan], self.last_phase[chan])
                 self.downsampler.value().add_sample(sample)  # Get the next sample from the Oscillator buffer using sinc interpolation
                 self.last_phase = phase
 
@@ -259,8 +259,8 @@ struct Osc[num_chans: Int = 1, interp: Interp = Interp.linear, ov_samp: TimesOve
             The next sample of the built-in basic waveforms.
         """
 
-        temp = self.world[].osc_buffers.value()
-        return temp[].at_phase_basic_waveform[self.interp](self.world, phase, last_phase)
+        ref temp = self.world[].osc_buffers()
+        return temp.at_phase_basic_waveform[self.interp](self.world, phase, last_phase)
 
     @always_inline 
     def next_basic_waveforms[

--- a/mmm_audio/Oversampling.mojo
+++ b/mmm_audio/Oversampling.mojo
@@ -229,29 +229,3 @@ struct OS_LPF4[num_chans: Int = 1](Movable, Copyable):
         """Reset the internal state of the 4th-order low-pass filter."""
         self.os_lpf1.reset()
         self.os_lpf2.reset()
-
-def create_subworld(world: World, times_ov_samp: TimesOversampling = TimesOversampling.none) -> UnsafePointer[MMMWorld, MutUntrackedOrigin]:
-    """Initializes the MMMWorld struct from a pointer to an existing World struct.
-
-    This is mostly used to create an oversampled subworld with a higher sample rate based on the main world.
-
-    Args:
-        world: A pointer to an existing World struct.
-        times_ov_samp: A [TimesOversampling](MMMWorld.md#struct-timesoversampling) struct to indicate times oversampling.
-
-    Returns:
-        A pointer to the MMMWorld struct.
-    """
-    new_world = alloc[MMMWorld](1) 
-    sample_rate = world[].sample_rate * Float64(times_ov_samp.times)
-    new_world.init_pointee_move(MMMWorld(
-        sample_rate, 
-        environment_ptr = world[].environment, 
-        osc_buffers_ptr = world[].osc_buffers, 
-        windows_ptr = world[].windows, 
-        messenger_manager_ptr = world[].messenger_manager, 
-        sinc_interpolator_ptr = world[].sinc_interpolator
-    ))
-
-    # print("SubWorld initialized with sample rate:", sample_rate)
-    return new_world

--- a/mmm_audio/Oversampling.mojo
+++ b/mmm_audio/Oversampling.mojo
@@ -246,7 +246,7 @@ def create_subworld(world: World, times_ov_samp: TimesOversampling = TimesOversa
     sample_rate = world[].sample_rate * Float64(times_ov_samp.times)
     new_world.init_pointee_move(MMMWorld(
         sample_rate, 
-        world_info_ptr = world[].world_info, 
+        environment_ptr = world[].environment, 
         osc_buffers_ptr = world[].osc_buffers, 
         windows_ptr = world[].windows, 
         messenger_manager_ptr = world[].messenger_manager, 

--- a/mmm_audio/Pan.mojo
+++ b/mmm_audio/Pan.mojo
@@ -70,8 +70,8 @@ def splay[num_simd: Int](*input: MFloat[num_simd], world: World) -> MFloat[2]:
 
             index0 = i // num_simd
             index1 = i % num_simd
-            temp = world[].windows.value()
-            pan_mul = temp[].at_pan[interp=Interp.none](world, pan)
+            ref temp = world[].windows()
+            pan_mul = temp.at_pan[interp=Interp.none](world, pan)
             out += input[index0][index1] * pan_mul
     return out
 
@@ -103,8 +103,8 @@ def splay[num_simd: Int](input: Span[MFloat[num_simd], ...], world: World) -> MF
 
             index0 = i // num_simd
             index1 = i % num_simd
-            temp = world[].windows.value()
-            pan_mul = temp[].at_pan[interp=Interp.none](world, pan)
+            ref temp = world[].windows()
+            pan_mul = temp.at_pan[interp=Interp.none](world, pan)
             out += input[index0][index1] * pan_mul
     return out
 
@@ -132,8 +132,8 @@ def splay[num_input_channels: Int](input: MFloat[num_input_channels], world: Wor
             out = input[0] * MFloat[2](0.7071, 0.7071)
         else:
             pan = Float64(i) / Float64(num_input_channels - 1)
-            temp = world[].windows.value()
-            pan_mul = temp[].at_pan[interp=Interp.none](world, pan)
+            ref temp = world[].windows()
+            pan_mul = temp.at_pan[interp=Interp.none](world, pan)
             out += input[i] * pan_mul
     return out
 

--- a/mmm_audio/Synthesizers.mojo
+++ b/mmm_audio/Synthesizers.mojo
@@ -32,7 +32,7 @@ struct PAF[
         Args:
             world: Pointer to the MMMWorld instance.
         """
-        self.oversampled_world = create_subworld(world, Self.ov_samp)
+        self.oversampled_world = world[].create_subworld(Self.ov_samp)
 
         self.phasor = Phasor[Self.num_chans](self.oversampled_world)
         
@@ -85,8 +85,8 @@ struct PAF[
                 freq=0, phase_offset=cos2_phase + 0.25
             )
 
-            temp = self.oversampled_world[].windows.value()
-            sin = temp[].at_phase[
+            ref temp = self.oversampled_world[].windows()
+            sin = temp.at_phase[
                 window_type=WindowType.sine, interp=Self.interp
             ](self.oversampled_world, phasor, self.sin_last_phase)
 
@@ -94,7 +94,7 @@ struct PAF[
                 sin * ((bandwidth / fundamental) * 0.25)
             ) + 0.5
 
-            gaussian = temp[].at_phase[
+            gaussian = temp.at_phase[
                 window_type=WindowType.gaussian, interp=Self.interp
             ](self.oversampled_world, gaussian_phase, self.gauss_last_phase)
 

--- a/mmm_python/MMMAudio.py
+++ b/mmm_python/MMMAudio.py
@@ -606,8 +606,13 @@ class MMMAudio:
             # Initialize Mojo audio bridge
             # =========================================================================
             
-            mmm_audio_bridge = MMMAudioBridge.MMMAudioBridge(sample_rate, blocksize)
-            mmm_audio_bridge.set_channel_count((actual_input_channels, actual_output_channels))
+            d = {
+                "sample_rate": sample_rate, 
+                "block_size": blocksize,
+                "num_in_chans": actual_input_channels, 
+                "num_out_chans": actual_output_channels
+                }
+            mmm_audio_bridge = MMMAudioBridge.MMMAudioBridge(d)
             # =========================================================================
             # Shared state for callback
             # =========================================================================

--- a/testing_mmm_audio/UnitTests.mojo
+++ b/testing_mmm_audio/UnitTests.mojo
@@ -471,15 +471,12 @@ def test_linmap() raises:
     assert_almost_equal(result, expected, "Test: linmap function failed")
 
 def test_env() raises:
-    osc_buffers: UnsafePointer[mut=True, OscBuffers, MutUntrackedOrigin] = alloc[OscBuffers](1)
-    osc_buffers.init_pointee_move(OscBuffers())
-    windows: UnsafePointer[mut=True, Windows, MutUntrackedOrigin] = alloc[Windows](1)
-    windows.init_pointee_move(Windows())
-    environment: UnsafePointer[mut=True, Environment, MutUntrackedOrigin] = alloc[Environment](1)
-    environment.init_pointee_move(Environment())
+
+    e = alloc[Environment](1)
+    e.init_pointee_move(Environment())
 
     world = alloc[MMMWorld](1) 
-    world.init_pointee_move(MMMWorld(48000., environment, osc_buffers, windows))
+    world.init_pointee_move(MMMWorld(48000.,e))
 
     x = MFloat[4](0.1, 0.25, 0.45, 1.5)
     result = MFloat[4](0.0, 0.0, 0.0, 0.0)

--- a/testing_mmm_audio/UnitTests.mojo
+++ b/testing_mmm_audio/UnitTests.mojo
@@ -475,11 +475,11 @@ def test_env() raises:
     osc_buffers.init_pointee_move(OscBuffers())
     windows: UnsafePointer[mut=True, Windows, MutUntrackedOrigin] = alloc[Windows](1)
     windows.init_pointee_move(Windows())
-    world_info: UnsafePointer[mut=True, WorldInfo, MutUntrackedOrigin] = alloc[WorldInfo](1)
-    world_info.init_pointee_move(WorldInfo())
+    environment: UnsafePointer[mut=True, Environment, MutUntrackedOrigin] = alloc[Environment](1)
+    environment.init_pointee_move(Environment())
 
     world = alloc[MMMWorld](1) 
-    world.init_pointee_move(MMMWorld(48000., world_info, osc_buffers, windows))
+    world.init_pointee_move(MMMWorld(48000., environment, osc_buffers, windows))
 
     x = MFloat[4](0.1, 0.25, 0.45, 1.5)
     result = MFloat[4](0.0, 0.0, 0.0, 0.0)

--- a/testing_mmm_audio/validation/Chroma_Validation.mojo
+++ b/testing_mmm_audio/validation/Chroma_Validation.mojo
@@ -19,11 +19,8 @@ struct ChromaTestSuite(FFTProcessable):
 def main() raises:
 	buf = Buffer.load("resources/Shiverer.wav")
 	
-	environment = alloc[Environment](1)
-	environment.init_pointee_move(Environment())
-
 	w = alloc[MMMWorld](1)
-	w.init_pointee_move(MMMWorld(buf.sample_rate, environment))
+	w.init_pointee_move(MMMWorld(buf.sample_rate))
 
 	chroma_ts = ChromaTestSuite(w)
 	fftprocess = FFTProcess[ChromaTestSuite,False,WindowType.hann](w, chroma_ts^, window_size=fftsize, hop_size=hopsize)

--- a/testing_mmm_audio/validation/Chroma_Validation.mojo
+++ b/testing_mmm_audio/validation/Chroma_Validation.mojo
@@ -19,11 +19,11 @@ struct ChromaTestSuite(FFTProcessable):
 def main() raises:
 	buf = Buffer.load("resources/Shiverer.wav")
 	
-	world_info = alloc[WorldInfo](1)
-	world_info.init_pointee_move(WorldInfo())
+	environment = alloc[Environment](1)
+	environment.init_pointee_move(Environment())
 
 	w = alloc[MMMWorld](1)
-	w.init_pointee_move(MMMWorld(buf.sample_rate, world_info))
+	w.init_pointee_move(MMMWorld(buf.sample_rate, environment))
 
 	chroma_ts = ChromaTestSuite(w)
 	fftprocess = FFTProcess[ChromaTestSuite,False,WindowType.hann](w, chroma_ts^, window_size=fftsize, hop_size=hopsize)

--- a/testing_mmm_audio/validation/MFCC_Validation.mojo
+++ b/testing_mmm_audio/validation/MFCC_Validation.mojo
@@ -20,11 +20,11 @@ struct MFCCTestSuite(FFTProcessable):
         self.data.append(self.mfcc.coeffs.copy())
 
 def main() raises:
-    world_info = alloc[WorldInfo](1)
-    world_info.init_pointee_move(WorldInfo())
+    environment = alloc[Environment](1)
+    environment.init_pointee_move(Environment())
     
     w = alloc[MMMWorld](1)
-    w.init_pointee_move(MMMWorld(44100, world_info))
+    w.init_pointee_move(MMMWorld(44100, environment))
     mfcc_ts = MFCCTestSuite(w)
     fftprocess = FFTProcess[MFCCTestSuite,False,WindowType.hann](w, mfcc_ts^, window_size=fftsize, hop_size=hopsize)
     buf = Buffer.load("resources/Shiverer.wav")

--- a/testing_mmm_audio/validation/MelBands_Validation.mojo
+++ b/testing_mmm_audio/validation/MelBands_Validation.mojo
@@ -17,11 +17,11 @@ struct MelBandsTestSuite(FFTProcessable):
         self.data.append(self.melbands.bands.copy())
 
 def main() raises:
-    world_info = alloc[WorldInfo](1)
-    world_info.init_pointee_move(WorldInfo())
+    environment = alloc[Environment](1)
+    environment.init_pointee_move(Environment())
     
     w = alloc[MMMWorld](1)
-    w.init_pointee_move(MMMWorld(48000, world_info))
+    w.init_pointee_move(MMMWorld(48000, environment))
     
     mbts = MelBandsTestSuite(w)
     fftprocess = FFTProcess[MelBandsTestSuite,False,WindowType.hann](w,mbts^, window_size=fftsize, hop_size=hopsize)

--- a/testing_mmm_audio/validation/RMS_Validation.mojo
+++ b/testing_mmm_audio/validation/RMS_Validation.mojo
@@ -19,11 +19,11 @@ struct Analyzer(BufferedProcessable):
         return
 
 def main():
-    world_info = alloc[WorldInfo](1)
-    world_info.init_pointee_move(WorldInfo())
+    environment = alloc[Environment](1)
+    environment.init_pointee_move(Environment())
     
     w = alloc[MMMWorld](1)
-    w.init_pointee_move(MMMWorld(44100, world_info))
+    w.init_pointee_move(MMMWorld(44100, environment))
 
     buffer = Buffer.load("resources/Shiverer.wav")
     playBuf = Play(w)

--- a/testing_mmm_audio/validation/SpectralCentroid_Validation.mojo
+++ b/testing_mmm_audio/validation/SpectralCentroid_Validation.mojo
@@ -26,11 +26,11 @@ struct Analyzer(BufferedProcessable):
         return
 
 def main():
-    world_info = alloc[WorldInfo](1)
-    world_info.init_pointee_move(WorldInfo())
+    environment = alloc[Environment](1)
+    environment.init_pointee_move(Environment())
     
     w = alloc[MMMWorld](1)
-    w.init_pointee_move(MMMWorld(44100, world_info))
+    w.init_pointee_move(MMMWorld(44100, environment))
 
     buffer = Buffer.load("resources/Shiverer.wav")
     playBuf = Play(w)

--- a/testing_mmm_audio/validation/SpectralCrest_Validation.mojo
+++ b/testing_mmm_audio/validation/SpectralCrest_Validation.mojo
@@ -24,11 +24,11 @@ struct Analyzer(BufferedProcessable):
         return
 
 def main():
-    world_info = alloc[WorldInfo](1)
-    world_info.init_pointee_move(WorldInfo())
+    environment = alloc[Environment](1)
+    environment.init_pointee_move(Environment())
     
     w = alloc[MMMWorld](1)
-    w.init_pointee_move(MMMWorld(44100, world_info))
+    w.init_pointee_move(MMMWorld(44100, environment))
 
     buffer = Buffer.load("resources/Shiverer.wav")
     playBuf = Play(w)

--- a/testing_mmm_audio/validation/SpectralFlatness_Validation.mojo
+++ b/testing_mmm_audio/validation/SpectralFlatness_Validation.mojo
@@ -24,11 +24,11 @@ struct Analyzer(BufferedProcessable):
         return
 
 def main():
-    world_info = alloc[WorldInfo](1)
-    world_info.init_pointee_move(WorldInfo())
+    environment = alloc[Environment](1)
+    environment.init_pointee_move(Environment())
     
     w = alloc[MMMWorld](1)
-    w.init_pointee_move(MMMWorld(44100, world_info))
+    w.init_pointee_move(MMMWorld(44100, environment))
 
     buffer = Buffer.load("resources/Shiverer.wav")
     playBuf = Play(w)

--- a/testing_mmm_audio/validation/SpectralKurtosis_Validation.mojo
+++ b/testing_mmm_audio/validation/SpectralKurtosis_Validation.mojo
@@ -24,11 +24,11 @@ struct Analyzer(BufferedProcessable):
         return
 
 def main():
-    world_info = alloc[WorldInfo](1)
-    world_info.init_pointee_move(WorldInfo())
+    environment = alloc[Environment](1)
+    environment.init_pointee_move(Environment())
     
     w = alloc[MMMWorld](1)
-    w.init_pointee_move(MMMWorld(44100, world_info))
+    w.init_pointee_move(MMMWorld(44100, environment))
 
     buffer = Buffer.load("resources/Shiverer.wav")
     playBuf = Play(w)

--- a/testing_mmm_audio/validation/SpectralRolloff_Validation.mojo
+++ b/testing_mmm_audio/validation/SpectralRolloff_Validation.mojo
@@ -24,11 +24,11 @@ struct Analyzer(BufferedProcessable):
         return
 
 def main():
-    world_info = alloc[WorldInfo](1)
-    world_info.init_pointee_move(WorldInfo())
+    environment = alloc[Environment](1)
+    environment.init_pointee_move(Environment())
     
     w = alloc[MMMWorld](1)
-    w.init_pointee_move(MMMWorld(44100, world_info))
+    w.init_pointee_move(MMMWorld(44100, environment))
 
     buffer = Buffer.load("resources/Shiverer.wav")
     playBuf = Play(w)

--- a/testing_mmm_audio/validation/SpectralSkewness_Validation.mojo
+++ b/testing_mmm_audio/validation/SpectralSkewness_Validation.mojo
@@ -24,11 +24,11 @@ struct Analyzer(BufferedProcessable):
         return
 
 def main():
-    world_info = alloc[WorldInfo](1)
-    world_info.init_pointee_move(WorldInfo())
+    environment = alloc[Environment](1)
+    environment.init_pointee_move(Environment())
     
     w = alloc[MMMWorld](1)
-    w.init_pointee_move(MMMWorld(44100, world_info))
+    w.init_pointee_move(MMMWorld(44100, environment))
 
     buffer = Buffer.load("resources/Shiverer.wav")
     playBuf = Play(w)

--- a/testing_mmm_audio/validation/SpectralSpread_Validation.mojo
+++ b/testing_mmm_audio/validation/SpectralSpread_Validation.mojo
@@ -24,11 +24,11 @@ struct Analyzer(BufferedProcessable):
         return
 
 def main():
-    world_info = alloc[WorldInfo](1)
-    world_info.init_pointee_move(WorldInfo())
+    environment = alloc[Environment](1)
+    environment.init_pointee_move(Environment())
     
     w = alloc[MMMWorld](1)
-    w.init_pointee_move(MMMWorld(44100, world_info))
+    w.init_pointee_move(MMMWorld(44100, environment))
 
     buffer = Buffer.load("resources/Shiverer.wav")
     playBuf = Play(w)

--- a/testing_mmm_audio/validation/YIN_Validation.mojo
+++ b/testing_mmm_audio/validation/YIN_Validation.mojo
@@ -34,11 +34,11 @@ struct Analyzer(BufferedProcessable):
         return
 
 def main():
-    world_info = alloc[WorldInfo](1)
-    world_info.init_pointee_move(WorldInfo())
+    environment = alloc[Environment](1)
+    environment.init_pointee_move(Environment())
     
     w = alloc[MMMWorld](1)
-    w.init_pointee_move(MMMWorld(44100, world_info))
+    w.init_pointee_move(MMMWorld(44100, environment))
 
     buffer = Buffer.load("resources/Shiverer.wav")
     w[].sample_rate = buffer.sample_rate


### PR DESCRIPTION
# World / Environment Refactor

The data / functionality is now broken into 3 structs:

* `MMMAudioBridge`: Just for getting messages from and to Python (such as audio for to/from hardware)
* `Environment`: Contains the necessary data for a World to operate (block size, num chans, messenger manager, windows, sinc interpolation, osc buffs, etc)
* `MMMWorld`: contains a samplerate and a pointer to the environment.

This structure teases apart a few different use cases:

1. only the sample rate is needed (for something like NRT analyses), MMMWorld's pointer to an Environment is an Optional, so it can just be completely ignored, but something like a NRT analysis can still grab a sample rate from MMMWorld. Not having an environment avoids the memory and compute overhead of things like Windows, OscBuffers, MessengerManager, and SincInterpolator.
2. The "things" (osc bufs, sinc interp, windows, etc) are needed, maybe for NRT synthesis or something. An Environment can be created and passed into a World so that World can now access what it needs. Even though the MessengerManager seems like it isn't necessarily needed for NRT synthesis (it *seems* like it might only be needed for *real-time* stuff to communicate with Python), I have some NRT synthesis stuff that "reads" a score (ala csound/sc) and that uses the MessengerManager. It enables certain code blocks to be run in either real-time or NRT and get "updates" to parameters using the same plumbing.
3. Real-time mode, well then yes, we need all three: MMMAudioBridge, Environment, MMMWorld.

This structure also keeps things in one place: The pointers aren't being passed around, their always accessed through a single pointer to a struct's "parent".

## `create_subworld` has moved

to become a method on World so create a new world now usually looks like:

```mojo
oversampled_world = world[].create_subworld(Self.timesoversampling)
```