### PR TITLE
fix top n peaks amps

### DIFF
--- a/mmm_audio/Analysis.mojo
+++ b/mmm_audio/Analysis.mojo
@@ -1531,10 +1531,11 @@ struct TopNFreqs(FFTProcessable, GetFloat64Featurable):
             index = self.output_peak_indices[i]
             if i < n_valid_peaks:
                 a_db = ampdb(MFloat[4](mags[index-1], mags[index], mags[index+1], 0.0))
-                val, mag = find_quadratic_peak(a_db[0], a_db[1], a_db[2])
+                val, mag_db = find_quadratic_peak(a_db[0], a_db[1], a_db[2])
                 offset = val - 1.0
                 freq = (MFloat[1](index) + offset) * self.bin_freq
-                self.freq_amp_pairs[i] = Tuple(freq, mag * (4.0/MFloat[1](self.window_size)))
+                mag_linear = dbamp(mag_db)
+                self.freq_amp_pairs[i] = Tuple(freq, mag_linear * (4.0/MFloat[1](self.window_size)))
             else:
                 self.freq_amp_pairs[i] = Tuple(0.0, 0.0)
         if self.sort_by_freq:


### PR DESCRIPTION
Just found this. I noticed the the amplitudes of the sine waves seemed off, as in the resynthesized timbres were very bright. I analyzed a saw tooth wave and found the the frequencies of the partials look good but the amplitudes did not since they should be `1/partial number`. 

This changes how the amplitudes are computed so the analysis now returns the expected amplitudes for a sawtooth wave (and therefore presumably other things too).

original:
```
freq: 439.44613692731565, freq ratio: 0.9987412202893537, amp: 0.09833471108340444, amp ratio: 1/1.0
freq: 879.5705593206886, freq ratio: 1.9990239984561105, amp: 0.08709073948034432, amp ratio: 1/1.129106397191607
freq: 1319.7992384770525, freq ratio: 2.9995437238114833, amp: 0.07967417018369839, amp ratio: 1/1.2342106714971983
freq: 1759.2886577025156, freq ratio: 3.9983833129602626, amp: 0.07463297390383418, amp ratio: 1/1.3175772844066262
freq: 2198.685856415191, freq ratio: 4.997013310034525, amp: 0.07101878447351272, amp ratio: 1/1.3846295992306024
```
fixed:

```
freq: 439.44613692731565, freq ratio: 0.9987412202893537, amp: 0.6428337092879101, amp ratio: 1/1.0
freq: 879.5705593206886, freq ratio: 1.9990239984561105, amp: 0.331324056158153, amp ratio: 1/1.9401963043126036
freq: 1319.7992384770525, freq ratio: 2.9995437238114833, amp: 0.21398769243688587, amp ratio: 1/3.004068607719153
freq: 1759.2886577025156, freq ratio: 3.9983833129602626, amp: 0.15897695367262915, amp ratio: 1/4.043565400124948
freq: 2198.685856415191, freq ratio: 4.997013310034525, amp: 0.12847272068667603, amp ratio: 1/5.003659188129723
```

```mojo
from mmm_audio import *

def main():
    e = alloc[Environment](1)
    e.init_pointee_move(Environment())
    w = alloc[MMMWorld](1)
    w.init_pointee_move(MMMWorld(48000,e))

    window_size = 2048

    fftp = FFTProcess[TopNFreqs](world=w,window_size=window_size,hop_size=window_size//2,process=TopNFreqs(
        sample_rate=w[].sample_rate,
        window_size=window_size,
        thresh=-70,
        num_peaks=5
    ))

    saw = Osc[interp=Interp.linear](w)

    for i in range(w[].sample_rate):
        _ = fftp.next(saw.next[OscType.saw](440.0))
        if (i % (w[].sample_rate // 10)) == 0:
            features = fftp.get_process().get_features()
            fund_amp = features[1]
            for i in range(0,len(features),2):
                print(t"freq: {features[i]}, freq ratio: {features[i]/440.0}, amp: {features[i+1]}, amp ratio: 1/{fund_amp/features[i+1]}")
            print("-------------------------")
```